### PR TITLE
Issue #20: show Play/Shuffle on selected artist song list

### DIFF
--- a/mobile/src/main/java/com/example/mymediaplayer/MainScreen.kt
+++ b/mobile/src/main/java/com/example/mymediaplayer/MainScreen.kt
@@ -718,8 +718,7 @@ fun MainScreen(
                         onClearCategorySelection = onClearCategorySelection,
                         enableAlphaIndex = true,
                         songs = uiState.library.filteredSongs,
-                        isPlaying = uiState.playback.isPlaying ||
-                            (uiState.playback.isPlayingPlaylist && uiState.playback.isPlaying),
+                        isPlaying = false,
                         isPlayingPlaylist = uiState.playback.isPlayingPlaylist,
                         hasNext = uiState.playback.hasNext,
                         hasPrev = uiState.playback.hasPrev,


### PR DESCRIPTION
Summary:
- Fix artist tab behavior so selected-artist song list shows Play/Shuffle controls like the other non-playlist list views.
- Remove the remaining conditional play-state branch that switched the artist list to transport controls.

Validation:
- ./gradlew :mobile:compileDebugKotlin

Closes #20