### PR TITLE
🧪 Add tests for MediaMetadataHelper

### DIFF
--- a/shared/src/test/java/com/example/mymediaplayer/shared/MediaMetadataHelperTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/MediaMetadataHelperTest.kt
@@ -1,0 +1,49 @@
+package com.example.mymediaplayer.shared
+
+import android.content.Context
+import android.net.Uri
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.shadows.ShadowMediaMetadataRetriever
+import org.robolectric.shadows.util.DataSource
+
+@RunWith(RobolectricTestRunner::class)
+class MediaMetadataHelperTest {
+
+    @Test
+    fun extractMetadata_withInvalidUri_returnsEmptyMediaMetadataInfo() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val invalidUriString = "this-is-not-a-valid-uri"
+
+        val result = MediaMetadataHelper.extractMetadata(context, invalidUriString)
+
+        // In Robolectric, an unconfigured DataSource does not throw an exception by default.
+        // It returns null for all metadata keys.
+        assertNull(result?.title)
+        assertNull(result?.album)
+        assertNull(result?.artist)
+        assertNull(result?.genre)
+        assertNull(result?.year)
+        assertNull(result?.durationMs)
+    }
+
+    @Test
+    fun extractMetadata_whenRetrieverThrowsException_returnsNull() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val uriString = "content://something/error"
+        val uri = Uri.parse(uriString)
+
+        // Configure ShadowMediaMetadataRetriever to throw an exception for this specific DataSource
+        val dataSource = DataSource.toDataSource(context, uri)
+        ShadowMediaMetadataRetriever.addException(dataSource, IllegalArgumentException("Simulated failure"))
+
+        val result = MediaMetadataHelper.extractMetadata(context, uriString)
+
+        // The exception caught block should return null
+        assertNull("Extracting metadata should return null if an exception is thrown", result)
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap in `MediaMetadataHelper.kt` was addressed by adding `MediaMetadataHelperTest.kt`.
📊 **Coverage:** The new tests cover scenarios for empty metadata (handled exception-free by Robolectric's default Shadow for invalid URIs) and exceptions thrown during `MediaMetadataRetriever` extraction using `ShadowMediaMetadataRetriever.addException`.
✨ **Result:** Increased test coverage for the media extraction utility and verified that the `catch (_: Exception)` block appropriately returns null, preventing crashes from malformed media inputs.

---
*PR created automatically by Jules for task [8678196814218476950](https://jules.google.com/task/8678196814218476950) started by @kimptoc*