### PR TITLE
🧹 Refactor `isSupportedAudioFile` to simplify boolean logic

### DIFF
--- a/shared/src/main/java/com/example/mymediaplayer/shared/MediaCacheService.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/MediaCacheService.kt
@@ -570,8 +570,7 @@ class MediaCacheService {
     internal fun isSupportedAudioFile(nameLowercase: String, mimeType: String?): Boolean {
         val mime = mimeType?.lowercase(Locale.US).orEmpty()
         if (mime.startsWith("audio/")) {
-            if (mime.contains("mpegurl") || mime.contains("x-mpegurl")) return false
-            return true
+            return !mime.contains("mpegurl") && !mime.contains("x-mpegurl")
         }
         if (mime == "application/ogg" || mime == "application/x-ogg") return true
         return SUPPORTED_AUDIO_EXTENSIONS.any { nameLowercase.endsWith(it) }


### PR DESCRIPTION
🎯 **What:** Simplified the nested `if` statements in `isSupportedAudioFile` to a single line boolean return statement in `MediaCacheService.kt`.

💡 **Why:** This makes the logic easier to read and less error-prone by avoiding multiple nesting levels, directly reflecting the boolean condition logic. It improves the code maintainability.

✅ **Verification:** Ran `test` suite via `./gradlew test` which passed successfully. Confirmed via review that this maintains functional equivalency.

✨ **Result:** The method is more concise and understandable while still correctly checking MIME types.

---
*PR created automatically by Jules for task [10091497305088195656](https://jules.google.com/task/10091497305088195656) started by @kimptoc*