### PR TITLE
Update data extraction rules for backup/transfer

### DIFF
--- a/mobile/src/main/res/xml/data_extraction_rules.xml
+++ b/mobile/src/main/res/xml/data_extraction_rules.xml
@@ -5,15 +5,11 @@
 -->
 <data-extraction-rules>
     <cloud-backup>
-        <!-- TODO: Use <include> and <exclude> to control what is backed up.
-        <include .../>
-        <exclude .../>
-        -->
+        <include domain="sharedpref" path="."/>
+        <exclude domain="sharedpref" path="device.xml"/>
     </cloud-backup>
-    <!--
     <device-transfer>
-        <include .../>
-        <exclude .../>
+        <include domain="sharedpref" path="."/>
+        <exclude domain="sharedpref" path="device.xml"/>
     </device-transfer>
-    -->
 </data-extraction-rules>


### PR DESCRIPTION
Resolves the TODO by replacing the commented out tags in `data_extraction_rules.xml` with standard include and exclude entries for `sharedpref`. Includes all shared preferences but explicitly excludes `device.xml` to mirror what is laid out as an example in `backup_rules.xml`.

---
*PR created automatically by Jules for task [11932684520531574361](https://jules.google.com/task/11932684520531574361) started by @kimptoc*