### PR TITLE
🧹 Refactor nested file insertion in MediaCacheService

### DIFF
--- a/shared/src/main/java/com/example/mymediaplayer/shared/MediaCacheService.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/MediaCacheService.kt
@@ -535,35 +535,61 @@ class MediaCacheService {
                     }
 
                     val isAudio = isSupportedAudioFile(lowerName, mimeType)
-                    if (isAudio) {
-                        val uri = DocumentsContract.buildDocumentUriUsingTree(treeUri, childId)
-                        candidates.add(
-                            FileCandidate(
-                                uri = uri,
-                                name = name,
-                                size = size,
-                                lastModified = lastModified,
-                                parentFolderName = parentFolderName,
-                                requiresProbe = false
-                            )
-                        )
-                    } else if (deepScan) {
-                        val uri = DocumentsContract.buildDocumentUriUsingTree(treeUri, childId)
-                        candidates.add(
-                            FileCandidate(
-                                uri = uri,
-                                name = name,
-                                size = size,
-                                lastModified = lastModified,
-                                parentFolderName = parentFolderName,
-                                requiresProbe = true
-                            )
-                        )
-                    } else {
-                        skippedReasons["unsupported_type"] = (skippedReasons["unsupported_type"] ?: 0) + 1
-                    }
+                    addFileCandidateIfNeeded(
+                        isAudio = isAudio,
+                        deepScan = deepScan,
+                        treeUri = treeUri,
+                        childId = childId,
+                        name = name,
+                        size = size,
+                        lastModified = lastModified,
+                        parentFolderName = parentFolderName,
+                        candidates = candidates,
+                        skippedReasons = skippedReasons
+                    )
                 }
             }
+        }
+    }
+
+    private fun addFileCandidateIfNeeded(
+        isAudio: Boolean,
+        deepScan: Boolean,
+        treeUri: Uri,
+        childId: String,
+        name: String,
+        size: Long,
+        lastModified: Long?,
+        parentFolderName: String?,
+        candidates: MutableList<FileCandidate>,
+        skippedReasons: MutableMap<String, Int>
+    ) {
+        if (isAudio) {
+            val uri = DocumentsContract.buildDocumentUriUsingTree(treeUri, childId)
+            candidates.add(
+                FileCandidate(
+                    uri = uri,
+                    name = name,
+                    size = size,
+                    lastModified = lastModified,
+                    parentFolderName = parentFolderName,
+                    requiresProbe = false
+                )
+            )
+        } else if (deepScan) {
+            val uri = DocumentsContract.buildDocumentUriUsingTree(treeUri, childId)
+            candidates.add(
+                FileCandidate(
+                    uri = uri,
+                    name = name,
+                    size = size,
+                    lastModified = lastModified,
+                    parentFolderName = parentFolderName,
+                    requiresProbe = true
+                )
+            )
+        } else {
+            skippedReasons["unsupported_type"] = (skippedReasons["unsupported_type"] ?: 0) + 1
         }
     }
 


### PR DESCRIPTION
🎯 **What:** Extracted the deeply nested file candidate insertion logic (the `isAudio` and `deepScan` conditionals) in `MediaCacheService.kt` into a new private helper function named `addFileCandidateIfNeeded`.
💡 **Why:** The original conditional block was large and deeply nested inside the `walkTree` while-loop. Extracting it into a helper function improves readability and maintainability by isolating the insertion logic.
✅ **Verification:** Ran `./gradlew test` across the whole project, confirming that all unit tests in the shared, mobile, and automotive modules pass without issues.
✨ **Result:** A much cleaner `walkTree` function with preserved functionality.

---
*PR created automatically by Jules for task [2682356410132836161](https://jules.google.com/task/2682356410132836161) started by @kimptoc*