### PR TITLE
🔒 Fix Intent spoofing vulnerability in MainActivity via activity-alias

### DIFF
--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -23,13 +23,18 @@
 
         <activity
             android:name=".MainActivity"
+            android:exported="false">
+        </activity>
+
+        <activity-alias
+            android:name=".LauncherActivity"
+            android:targetActivity=".MainActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
-        </activity>
+        </activity-alias>
 
         <receiver
             android:name=".BluetoothAutoPlayReceiver"


### PR DESCRIPTION
🎯 **What:** The `MainActivity` component was overly exposed due to `android:exported="true"` without intent restrictions.
⚠️ **Risk:** An attacker or malicious app could explicitly target the component and pass unexpected extras/intents, leading to intent spoofing or unintended app state execution.
🛡️ **Solution:** Implemented the `<activity-alias>` pattern. The `.LauncherActivity` alias remains exported to handle `MAIN`/`LAUNCHER` requests, while `.MainActivity` is now correctly set to `android:exported="false"`, ensuring it only receives intents passed securely via the alias or internally.

---
*PR created automatically by Jules for task [10637354065517432084](https://jules.google.com/task/10637354065517432084) started by @kimptoc*