### PR TITLE
Fix missing SSML parameter in TTS speak() calls

### DIFF
--- a/shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
@@ -1340,7 +1340,10 @@ class MyMusicService : MediaBrowserServiceCompat() {
         val utteranceId = "track_intro_${SystemClock.elapsedRealtime()}"
         val action = PendingSpeechAction(utteranceId, onComplete)
         pendingSpeechAction.set(action)
-        val result = tts.speak(introText, TextToSpeech.QUEUE_FLUSH, null, utteranceId)
+        val params = Bundle().apply {
+            putString(TextToSpeech.Engine.KEY_FEATURE_UTTERANCE_PARAM_SSML, "true")
+        }
+        val result = tts.speak(introText, TextToSpeech.QUEUE_FLUSH, params, utteranceId)
         if (result == TextToSpeech.ERROR) {
             if (pendingSpeechAction.compareAndSet(action, null)) {
                 onComplete()
@@ -1370,7 +1373,10 @@ class MyMusicService : MediaBrowserServiceCompat() {
         val utteranceId = "track_outro_${SystemClock.elapsedRealtime()}"
         val action = PendingSpeechAction(utteranceId, onComplete)
         pendingSpeechAction.set(action)
-        val result = tts.speak(outroText, TextToSpeech.QUEUE_FLUSH, null, utteranceId)
+        val params = Bundle().apply {
+            putString(TextToSpeech.Engine.KEY_FEATURE_UTTERANCE_PARAM_SSML, "true")
+        }
+        val result = tts.speak(outroText, TextToSpeech.QUEUE_FLUSH, params, utteranceId)
         if (result == TextToSpeech.ERROR) {
             if (pendingSpeechAction.compareAndSet(action, null)) {
                 onComplete()


### PR DESCRIPTION
## Summary

- Pass explicit SSML `Bundle` params to both `tts.speak()` calls (intro and outro)
- Fixes the TTS engine silently treating SSML as plain text, which could cause
  tags like `<speak>` and `<emphasis>` to be read aloud literally

## Changes

Both call sites in `MyMusicService.kt` updated identically:

```kotlin
val params = Bundle().apply {
    putString(TextToSpeech.Engine.KEY_FEATURE_UTTERANCE_PARAM_SSML, "true")
}
tts.speak(text, TextToSpeech.QUEUE_FLUSH, params, utteranceId)
