### PR TITLE
🧹 Refactor MainActivity's onCreate to improve readability

### DIFF
--- a/mobile/src/main/java/com/example/mymediaplayer/MainActivity.kt
+++ b/mobile/src/main/java/com/example/mymediaplayer/MainActivity.kt
@@ -252,43 +252,19 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         volumeControlStream = AudioManager.STREAM_MUSIC
-        bluetoothAutoPlayEnabled = getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
-            .getBoolean(KEY_BT_AUTOPLAY_ENABLED, false)
-        trackVoiceIntroEnabled = getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
-            .getBoolean(KEY_TRACK_VOICE_INTRO_ENABLED, false)
-        trackVoiceOutroEnabled = getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
-            .getBoolean(KEY_TRACK_VOICE_OUTRO_ENABLED, false)
-        debugCloudAnnouncements = getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
-            .getBoolean(KEY_DEBUG_CLOUD_ANNOUNCEMENTS, false)
-        val encryptedPrefs = com.example.mymediaplayer.shared.ApiKeyStore.getPrefs(this)
-        cloudAnnouncementKiloKey = encryptedPrefs
-            ?.getString(com.example.mymediaplayer.shared.ApiKeyStore.KEY_KILO, "") ?: ""
-        cloudAnnouncementTtsKey = encryptedPrefs
-            ?.getString(com.example.mymediaplayer.shared.ApiKeyStore.KEY_CLOUD_TTS, "") ?: ""
+
+        loadPreferences()
+
         refreshBluetoothState()
         maybeRequestPostNotifications()
 
         restoreLastTreeUri()
         showPlaylistSaveFolderPrompt = !hasValidPlaylistSaveFolder()
 
-        mediaBrowser = MediaBrowserCompat(
-            this,
-            ComponentName(this, MyMusicService::class.java),
-            connectionCallback,
-            null
-        ).apply { connect() }
+        setupMediaBrowser()
         handleIncomingIntent(intent)
 
-        lifecycleScope.launch {
-            viewModel.uiState.collect { state ->
-                if (state.scan.scannedFiles.isNotEmpty()) {
-                    sendFilesToServiceIfNeeded(state.scan.scannedFiles)
-                }
-                if (state.scan.discoveredPlaylists.isNotEmpty()) {
-                    sendPlaylistsToServiceIfNeeded(state.scan.discoveredPlaylists)
-                }
-            }
-        }
+        observeViewModel()
 
         setContent {
             MaterialTheme {
@@ -501,6 +477,44 @@ class MainActivity : ComponentActivity() {
                 )
             }
         }
+    }
+
+    private fun observeViewModel() {
+        lifecycleScope.launch {
+            viewModel.uiState.collect { state ->
+                if (state.scan.scannedFiles.isNotEmpty()) {
+                    sendFilesToServiceIfNeeded(state.scan.scannedFiles)
+                }
+                if (state.scan.discoveredPlaylists.isNotEmpty()) {
+                    sendPlaylistsToServiceIfNeeded(state.scan.discoveredPlaylists)
+                }
+            }
+        }
+    }
+
+    private fun setupMediaBrowser() {
+        mediaBrowser = MediaBrowserCompat(
+            this,
+            ComponentName(this, MyMusicService::class.java),
+            connectionCallback,
+            null
+        ).apply { connect() }
+    }
+
+    private fun loadPreferences() {
+        bluetoothAutoPlayEnabled = getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
+            .getBoolean(KEY_BT_AUTOPLAY_ENABLED, false)
+        trackVoiceIntroEnabled = getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
+            .getBoolean(KEY_TRACK_VOICE_INTRO_ENABLED, false)
+        trackVoiceOutroEnabled = getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
+            .getBoolean(KEY_TRACK_VOICE_OUTRO_ENABLED, false)
+        debugCloudAnnouncements = getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
+            .getBoolean(KEY_DEBUG_CLOUD_ANNOUNCEMENTS, false)
+        val encryptedPrefs = com.example.mymediaplayer.shared.ApiKeyStore.getPrefs(this)
+        cloudAnnouncementKiloKey = encryptedPrefs
+            ?.getString(com.example.mymediaplayer.shared.ApiKeyStore.KEY_KILO, "") ?: ""
+        cloudAnnouncementTtsKey = encryptedPrefs
+            ?.getString(com.example.mymediaplayer.shared.ApiKeyStore.KEY_CLOUD_TTS, "") ?: ""
     }
 
     private fun maybeRequestPostNotifications() {


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Extracted multiple logical blocks from the overly long `onCreate` method in `MainActivity.kt` into smaller, dedicated functions (`loadPreferences`, `setupMediaBrowser`, `observeViewModel`).

💡 **Why:** How this improves maintainability
`onCreate` was handling too many initializations inline, making it difficult to read and maintain. By delegating specific setup tasks to private helper methods, the core lifecycle method is much cleaner and easier to understand.

✅ **Verification:** How you confirmed the change is safe
Ran mobile unit tests (`./gradlew :mobile:testDebugUnitTest`) to ensure no functionality was broken. Code review confirmed the refactoring is structural and safe.

✨ **Result:** The improvement achieved
A cleaner, more modular `MainActivity` with significantly reduced cognitive load in the `onCreate` lifecycle hook.

---
*PR created automatically by Jules for task [14744360533256528563](https://jules.google.com/task/14744360533256528563) started by @kimptoc*