### PR TITLE
🧪 [Test ApiKeyStore exception handling]

### DIFF
--- a/shared/src/test/java/com/example/mymediaplayer/shared/ApiKeyStoreTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/ApiKeyStoreTest.kt
@@ -1,0 +1,45 @@
+package com.example.mymediaplayer.shared
+
+import android.content.Context
+import android.content.ContextWrapper
+import android.content.SharedPreferences
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.security.GeneralSecurityException
+
+@RunWith(RobolectricTestRunner::class)
+class ApiKeyStoreTest {
+
+    @Test
+    fun getPrefs_success_returnsSharedPreferences() {
+        val baseContext = ApplicationProvider.getApplicationContext<Context>()
+        val result = ApiKeyStore.getPrefs(baseContext)
+        assertNotNull("getPrefs should return a SharedPreferences instance on success", result)
+    }
+
+    @Test
+    fun getPrefs_whenExceptionThrown_returnsNull() {
+        val baseContext = ApplicationProvider.getApplicationContext<Context>()
+
+        // Create a custom ContextWrapper that throws an exception when
+        // SharedPreferences are requested, simulating a failure in
+        // EncryptedSharedPreferences or Android Keystore.
+        val failingContext = object : ContextWrapper(baseContext) {
+            override fun getApplicationContext(): Context {
+                return this
+            }
+
+            override fun getSharedPreferences(name: String?, mode: Int): SharedPreferences {
+                throw GeneralSecurityException("Simulated Keystore failure")
+            }
+        }
+
+        val result = ApiKeyStore.getPrefs(failingContext)
+
+        assertNull("getPrefs should return null when an exception occurs", result)
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap in `ApiKeyStore.getPrefs()` exception handling has been addressed.
📊 **Coverage:** The happy path and the exception failure path (simulating Android Keystore or EncryptedSharedPreferences failure) are now covered.
✨ **Result:** Test coverage for the `ApiKeyStore` secure storage component has been significantly improved, ensuring the fallback behavior (returning `null`) is correctly executed when an error occurs.

---
*PR created automatically by Jules for task [7510280409557797825](https://jules.google.com/task/7510280409557797825) started by @kimptoc*