### PR TITLE
🧹 Flatten `readPlaylist` parsing logic for better readability

### DIFF
--- a/shared/src/main/java/com/example/mymediaplayer/shared/PlaylistService.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/PlaylistService.kt
@@ -265,35 +265,44 @@ class PlaylistService {
             BufferedReader(InputStreamReader(inputStream)).use { reader ->
                 var pendingTitle: String? = null
                 reader.lineSequence().forEach { line ->
-                    val trimmed = line.trim()
-                    if (trimmed.isEmpty()) return@forEach
-                    if (trimmed.startsWith("#EXTINF:", ignoreCase = true)) {
-                        val commaIndex = trimmed.indexOf(',')
-                        pendingTitle = if (commaIndex >= 0 && commaIndex + 1 < trimmed.length) {
-                            trimmed.substring(commaIndex + 1).trim().ifEmpty { null }
-                        } else {
-                            null
-                        }
-                        return@forEach
-                    }
-                    if (trimmed.startsWith("#")) return@forEach
-
-                    val uri = Uri.parse(trimmed)
-                    val name = pendingTitle ?: uri.lastPathSegment ?: "Unknown"
-                    results.add(
-                        MediaFileInfo(
-                            uriString = trimmed,
-                            displayName = name,
-                            sizeBytes = 0L,
-                            title = name
-                        )
-                    )
-                    pendingTitle = null
+                    pendingTitle = processPlaylistLine(line, pendingTitle, results)
                 }
             }
         } catch (e: IOException) {
             Log.e(TAG, "I/O error reading playlist content: $playlistUri", e)
         }
         return results
+    }
+
+    private fun processPlaylistLine(
+        line: String,
+        pendingTitle: String?,
+        results: MutableList<MediaFileInfo>
+    ): String? {
+        val trimmed = line.trim()
+        if (trimmed.isEmpty()) return pendingTitle
+
+        if (trimmed.startsWith("#EXTINF:", ignoreCase = true)) {
+            val commaIndex = trimmed.indexOf(',')
+            return if (commaIndex >= 0 && commaIndex + 1 < trimmed.length) {
+                trimmed.substring(commaIndex + 1).trim().ifEmpty { null }
+            } else {
+                null
+            }
+        }
+
+        if (trimmed.startsWith("#")) return pendingTitle
+
+        val uri = Uri.parse(trimmed)
+        val name = pendingTitle ?: uri.lastPathSegment ?: "Unknown"
+        results.add(
+            MediaFileInfo(
+                uriString = trimmed,
+                displayName = name,
+                sizeBytes = 0L,
+                title = name
+            )
+        )
+        return null
     }
 }


### PR DESCRIPTION
🎯 **What:** Extracted the M3U line parsing logic inside `PlaylistService.readPlaylist` into a separate method `processPlaylistLine`.
💡 **Why:** The original `readPlaylist` function had a deeply nested `forEach` block for parsing M3U files, which reduced code readability and maintainability. Flattening it improves clarity.
✅ **Verification:** Verified by running all unit tests in the `:shared` module, particularly the `PlaylistServiceTest`. Ensure existing M3U file parsing functionality remains completely unchanged.
✨ **Result:** Improved codebase maintainability and readability with flatter control flow.

---
*PR created automatically by Jules for task [12695124953681804089](https://jules.google.com/task/12695124953681804089) started by @kimptoc*