### PR TITLE
🧹 Refactor deep nesting in `loadWholeDriveGenres`

### DIFF
--- a/shared/src/main/java/com/example/mymediaplayer/shared/MediaCacheService.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/MediaCacheService.kt
@@ -181,27 +181,36 @@ class MediaCacheService {
                 val genreId = genreCursor.getLong(genreIdIndex)
                 val genreName = genreCursor.getString(genreNameIndex)?.trim().orEmpty()
                 if (genreName.isBlank()) continue
-                val membersUri = MediaStore.Audio.Genres.Members.getContentUri("external", genreId)
-                resolver.query(
-                    membersUri,
-                    arrayOf(MediaStore.Audio.Genres.Members.AUDIO_ID),
-                    null,
-                    null,
-                    null
-                )?.use { membersCursor ->
-                    val audioIdIndex =
-                        membersCursor.getColumnIndexOrThrow(MediaStore.Audio.Genres.Members.AUDIO_ID)
-                    while (membersCursor.moveToNext()) {
-                        val audioId = membersCursor.getLong(audioIdIndex)
-                        if (audioId !in audioIds) continue
-                        if (genresByAudioId[audioId].isNullOrBlank()) {
-                            genresByAudioId[audioId] = genreName
-                        }
-                    }
-                }
+                processGenreMembers(resolver, genreId, genreName, audioIds, genresByAudioId)
             }
         }
         return genresByAudioId
+    }
+
+    private fun processGenreMembers(
+        resolver: android.content.ContentResolver,
+        genreId: Long,
+        genreName: String,
+        audioIds: Set<Long>,
+        genresByAudioId: MutableMap<Long, String>
+    ) {
+        val membersUri = MediaStore.Audio.Genres.Members.getContentUri("external", genreId)
+        resolver.query(
+            membersUri,
+            arrayOf(MediaStore.Audio.Genres.Members.AUDIO_ID),
+            null,
+            null,
+            null
+        )?.use { membersCursor ->
+            val audioIdIndex = membersCursor.getColumnIndexOrThrow(MediaStore.Audio.Genres.Members.AUDIO_ID)
+            while (membersCursor.moveToNext()) {
+                val audioId = membersCursor.getLong(audioIdIndex)
+                if (audioId !in audioIds) continue
+                if (genresByAudioId[audioId].isNullOrBlank()) {
+                    genresByAudioId[audioId] = genreName
+                }
+            }
+        }
     }
 
     fun enrichGenresFromMediaStore(context: Context) {


### PR DESCRIPTION
🎯 **What:** Extracted the inner `resolver.query()` logic in `loadWholeDriveGenres` into a separate function called `processGenreMembers`.
💡 **Why:** This reduces deep nesting, making the code much easier to read and maintain.
✅ **Verification:** Ran `./gradlew :shared:testDebugUnitTest` and confirmed all unit tests pass. Reviewed the code changes for proper scoping and behavior (passing `ContentResolver` explicitly to the extracted method).
✨ **Result:** Improved the code health by simplifying complex, deeply nested logic within `MediaCacheService.kt`.

---
*PR created automatically by Jules for task [11261265586834502428](https://jules.google.com/task/11261265586834502428) started by @kimptoc*