### PR TITLE
🧹 Code Health Improvement: Extract `buildMediaItems` logic into helpers

### DIFF
--- a/shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
@@ -681,8 +681,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
         result.sendResult(items)
     }
 
-    internal fun buildMediaItems(parentId: String): MutableList<MediaItem> {
-        val start = SystemClock.elapsedRealtime()
+    private fun buildMediaItemsForPrefix(parentId: String): MutableList<MediaItem>? {
         if (parentId.startsWith(SMART_PLAYLIST_PREFIX)) {
             val smartId = Uri.decode(parentId.removePrefix(SMART_PLAYLIST_PREFIX))
             val tracks = resolveSmartPlaylistTracksById(smartId) ?: emptyList()
@@ -788,7 +787,11 @@ class MyMusicService : MediaBrowserServiceCompat() {
             )
         }
 
-        val items = when (parentId) {
+        return null
+    }
+
+    private fun buildMediaItemsForId(parentId: String): MutableList<MediaItem> {
+        return when (parentId) {
             ROOT_ID -> {
                 val items = mutableListOf<MediaItem>()
                 items.add(
@@ -851,7 +854,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
                     )
                 }
                 items
-        }
+            }
             SONGS_ALL_ID -> {
                 val titles = mediaCacheService.cachedFiles.map { it.cleanTitle }
                 buildCategoryListItems(
@@ -942,6 +945,20 @@ class MyMusicService : MediaBrowserServiceCompat() {
             }
             else -> mutableListOf()
         }
+    }
+
+    internal fun buildMediaItems(parentId: String): MutableList<MediaItem> {
+        val start = SystemClock.elapsedRealtime()
+
+        val prefixItems = buildMediaItemsForPrefix(parentId)
+        if (prefixItems != null) {
+            val elapsed = SystemClock.elapsedRealtime() - start
+            Log.d("MyMusicService", "buildMediaItems($parentId) -> ${prefixItems.size} in ${elapsed}ms")
+            return prefixItems
+        }
+
+        val items = buildMediaItemsForId(parentId)
+
         val elapsed = SystemClock.elapsedRealtime() - start
         Log.d("MyMusicService", "buildMediaItems($parentId) -> ${items.size} in ${elapsed}ms")
         return items


### PR DESCRIPTION
🎯 **What:** The `buildMediaItems` function in `MyMusicService.kt` was overly long and complex. It has been refactored by extracting its logic into two distinct helper methods: `buildMediaItemsForPrefix` and `buildMediaItemsForId`.

💡 **Why:** This refactoring significantly improves the readability and maintainability of the `MyMusicService` class. It simplifies the main logic loop and makes the codebase easier to understand, trace, and test, adhering to standard clean-code principles.

✅ **Verification:** After making the changes, the `./gradlew :shared:test` test suite was run and passed successfully, confirming that the extracted code behaves exactly as it did before. A Code Review was conducted, returning a rating of #Correct#.

✨ **Result:** A more modular and readable `buildMediaItems` function with preserved functionality and identical outputs.

---
*PR created automatically by Jules for task [7897666526541367390](https://jules.google.com/task/7897666526541367390) started by @kimptoc*