### PR TITLE
🧪 Add tests for NetworkQualityChecker

### DIFF
--- a/shared/src/test/java/com/example/mymediaplayer/shared/NetworkQualityCheckerTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/NetworkQualityCheckerTest.kt
@@ -1,0 +1,187 @@
+package com.example.mymediaplayer.shared
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowConnectivityManager
+import org.robolectric.shadows.ShadowNetworkCapabilities
+import java.net.HttpURLConnection
+import java.net.URL
+import java.net.URLConnection
+import java.net.URLStreamHandler
+import java.net.URLStreamHandlerFactory
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class NetworkQualityCheckerTest {
+
+    private lateinit var context: Context
+    private lateinit var checker: NetworkQualityChecker
+    private lateinit var connectivityManager: ConnectivityManager
+    private lateinit var shadowConnectivityManager: ShadowConnectivityManager
+
+    companion object {
+        var mockLatencyMs: Long = 0
+        var mockFailConnection = false
+        var factoryInstalled = false
+
+        fun installMockFactory() {
+            if (!factoryInstalled) {
+                try {
+                    URL.setURLStreamHandlerFactory { protocol ->
+                        if (protocol == "https") {
+                            object : URLStreamHandler() {
+                                override fun openConnection(u: URL): URLConnection {
+                                    return object : HttpURLConnection(u) {
+                                        override fun connect() {
+                                            if (mockFailConnection) throw java.io.IOException("Mock connection failed")
+                                            Thread.sleep(mockLatencyMs) // simulate latency
+                                        }
+                                        override fun disconnect() {}
+                                        override fun usingProxy(): Boolean = false
+                                    }
+                                }
+                            }
+                        } else {
+                            null
+                        }
+                    }
+                    factoryInstalled = true
+                } catch (e: Error) {
+                    // Factory already set
+                }
+            }
+        }
+    }
+
+    @Before
+    fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+        checker = NetworkQualityChecker(context)
+
+        connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        shadowConnectivityManager = shadowOf(connectivityManager)
+
+        mockLatencyMs = 0
+        mockFailConnection = false
+
+        installMockFactory()
+    }
+
+    @Test
+    fun check_noActiveNetwork_returnsNone() = runBlocking {
+        shadowConnectivityManager.setDefaultNetworkActive(false)
+        assertEquals(NetworkQualityChecker.Quality.NONE, checker.check())
+    }
+
+    @Test
+    fun check_nullNetworkCapabilities_returnsNone() = runBlocking {
+        shadowConnectivityManager.setDefaultNetworkActive(true)
+        val network = connectivityManager.activeNetwork
+        assertEquals(NetworkQualityChecker.Quality.NONE, checker.check())
+    }
+
+    @Test
+    fun check_noInternetCapability_returnsNone() = runBlocking {
+        shadowConnectivityManager.setDefaultNetworkActive(true)
+        val network = connectivityManager.activeNetwork!!
+
+        val capabilities = ShadowNetworkCapabilities.newInstance()
+        shadowOf(connectivityManager).setNetworkCapabilities(network, capabilities)
+
+        assertEquals(NetworkQualityChecker.Quality.NONE, checker.check())
+    }
+
+    @Test
+    fun check_noValidatedCapability_returnsPoor() = runBlocking {
+        shadowConnectivityManager.setDefaultNetworkActive(true)
+        val network = connectivityManager.activeNetwork!!
+
+        val capabilities = ShadowNetworkCapabilities.newInstance()
+        shadowOf(capabilities).addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+        shadowOf(connectivityManager).setNetworkCapabilities(network, capabilities)
+
+        assertEquals(NetworkQualityChecker.Quality.POOR, checker.check())
+    }
+
+    @Test
+    fun check_returnsCachedResult() = runBlocking {
+        shadowConnectivityManager.setDefaultNetworkActive(false)
+
+        val result1 = checker.check()
+        assertEquals(NetworkQualityChecker.Quality.NONE, result1)
+
+        shadowConnectivityManager.setDefaultNetworkActive(true)
+        val network = connectivityManager.activeNetwork!!
+        val capabilities = ShadowNetworkCapabilities.newInstance()
+        shadowOf(capabilities).addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+        shadowOf(capabilities).addCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+        shadowOf(connectivityManager).setNetworkCapabilities(network, capabilities)
+
+        val result2 = checker.check()
+
+        assertEquals(NetworkQualityChecker.Quality.NONE, result2)
+    }
+
+    @Test
+    fun check_afterInvalidate_returnsNewResult() = runBlocking {
+        shadowConnectivityManager.setDefaultNetworkActive(false)
+
+        assertEquals(NetworkQualityChecker.Quality.NONE, checker.check())
+
+        checker.invalidate()
+
+        shadowConnectivityManager.setDefaultNetworkActive(true)
+        val network = connectivityManager.activeNetwork!!
+        val capabilities = ShadowNetworkCapabilities.newInstance()
+        shadowOf(capabilities).addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+        shadowOf(connectivityManager).setNetworkCapabilities(network, capabilities)
+
+        assertEquals(NetworkQualityChecker.Quality.POOR, checker.check())
+    }
+
+    @Test
+    fun check_latencyUnderThreshold_returnsGood() = runBlocking {
+        setupNetworkForPing()
+        mockLatencyMs = 50L
+
+        assertEquals(NetworkQualityChecker.Quality.GOOD, checker.check())
+    }
+
+    @Test
+    fun check_latencyOverThreshold_returnsPoor() = runBlocking {
+        setupNetworkForPing()
+        mockLatencyMs = 250L
+
+        assertEquals(NetworkQualityChecker.Quality.POOR, checker.check())
+    }
+
+    @Test
+    fun check_pingFails_returnsPoor() = runBlocking {
+        setupNetworkForPing()
+        mockFailConnection = true
+
+        assertEquals(NetworkQualityChecker.Quality.POOR, checker.check())
+    }
+
+    private fun setupNetworkForPing() {
+        shadowConnectivityManager.setDefaultNetworkActive(true)
+        val network = connectivityManager.activeNetwork!!
+        val capabilities = ShadowNetworkCapabilities.newInstance()
+        shadowOf(capabilities).addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+        shadowOf(capabilities).addCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+        shadowOf(connectivityManager).setNetworkCapabilities(network, capabilities)
+        checker.invalidate()
+    }
+}


### PR DESCRIPTION
🎯 **What:** The `NetworkQualityChecker.check()` method lacked test coverage. Testing this method required mocking Android's networking framework (`ConnectivityManager`, `NetworkCapabilities`) and the `HttpURLConnection` used for measuring latency.
📊 **Coverage:** The tests now cover:
- No active network -> Returns `NONE`.
- Null `NetworkCapabilities` -> Returns `NONE`.
- Active network missing `NET_CAPABILITY_INTERNET` -> Returns `NONE`.
- Active network missing `NET_CAPABILITY_VALIDATED` -> Returns `POOR`.
- Successful latency measurement under threshold -> Returns `GOOD`.
- Successful latency measurement over threshold -> Returns `POOR`.
- Failed latency measurement (ping fails) -> Returns `POOR`.
- Caching behavior -> Returns cached result within TTL.
- Cache invalidation -> Triggers a new network measurement.
✨ **Result:** Comprehensive test suite created for `NetworkQualityChecker`, increasing reliability and test coverage by validating all edge cases, caching paths, and network failure states.

---
*PR created automatically by Jules for task [13357019067218228053](https://jules.google.com/task/13357019067218228053) started by @kimptoc*