### PR TITLE
Fix empty cache being treated as valid in scan functions

### DIFF
--- a/mobile/src/main/java/com/example/mymediaplayer/MainViewModel.kt
+++ b/mobile/src/main/java/com/example/mymediaplayer/MainViewModel.kt
@@ -206,7 +206,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             if (!forceRescan && !deepScan) {
                 val persisted =
                     mediaCacheService.loadPersistedCache(getApplication(), treeUri, maxFiles)
-                if (persisted != null) {
+                if (persisted != null && persisted.files.isNotEmpty()) {
                     scanCache[key] = persisted.files to persisted.playlists
                     _uiState.value = resetAfterScan(
                         persisted.files,
@@ -320,7 +320,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                 val wholeDeviceUri = MediaStore.Audio.Media.EXTERNAL_CONTENT_URI
                 val persisted =
                     mediaCacheService.loadPersistedCache(getApplication(), wholeDeviceUri, maxFiles)
-                if (persisted != null) {
+                if (persisted != null && persisted.files.isNotEmpty()) {
                     scanCache[key] = persisted.files to persisted.playlists
                     _uiState.value = resetAfterScan(
                         persisted.files,


### PR DESCRIPTION
## Summary

- Follow-up to #58 — `loadPersistedCache()` can return a valid cache with 0 files (e.g. if the service persisted an empty scan state). Both `scanWholeDevice()` and `onDirectorySelected()` now guard against this with `persisted.files.isNotEmpty()`, falling through to a full scan instead of showing an empty song list.

## Test plan

- [ ] Open app in whole-device mode — should do full scan on first open, then load from cache on subsequent opens with actual songs
- [ ] Unit tests: `./gradlew :mobile:testDebugUnitTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)