### PR TITLE
Fix Android Auto queue showing content:// URIs instead of song titles

### DIFF
--- a/shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
@@ -1780,23 +1780,25 @@ class MyMusicService : MediaBrowserServiceCompat() {
         savePlaybackSnapshot(positionMsOverride = 0L)
     }
 
-    private fun refreshQueueMetadata() {
+    private suspend fun refreshQueueMetadata() {
         if (playlistQueue.isEmpty()) return
         val byUri = mediaCacheService.getFileIndexByUri()
-        var changed = false
-        playlistQueue = playlistQueue.map { fileInfo ->
-            val cached = byUri[fileInfo.uriString]
-            if (cached != null && cached.title != fileInfo.title) {
-                changed = true
-                cached
-            } else {
-                fileInfo
+        playMutex.withLock {
+            var changed = false
+            playlistQueue = playlistQueue.map { fileInfo ->
+                val cached = byUri[fileInfo.uriString]
+                if (cached != null && cached.title != fileInfo.title) {
+                    changed = true
+                    cached
+                } else {
+                    fileInfo
+                }
             }
-        }
-        if (changed) {
-            currentFileInfo = playlistQueue.getOrNull(currentQueueIndex) ?: currentFileInfo
-            updateSessionQueue()
-            currentFileInfo?.let { updateMetadata(it) }
+            if (changed) {
+                currentFileInfo = playlistQueue.getOrNull(currentQueueIndex) ?: currentFileInfo
+                updateSessionQueue()
+                currentFileInfo?.let { updateMetadata(it) }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- Added `refreshQueueMetadata()` that re-resolves queue items against the media cache once it loads, replacing raw `content://` URIs with actual song titles and artist names
- Called in both the cache-load and scan completion paths of `loadCachedTreeIfAvailable()`
- Added `persisted.files.isNotEmpty()` guard to the service's cache-load path (matching the phone-side fix in #59)

**Root cause:** `restorePlaybackSnapshot()` runs in `onCreate()` before `loadCachedTreeIfAvailable()`, so the media cache is empty when queue items are restored. Fallback `MediaFileInfo` objects are created with the raw URI as the title.

## Test plan

- [ ] Play music, close app, reconnect Android Auto — queue should show song titles not URIs
- [ ] Unit tests: `./gradlew :shared:testDebugUnitTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)