### PR TITLE
Fix expanded player progress bar not updating during playback

### DIFF
--- a/mobile/src/main/java/com/example/mymediaplayer/MainScreen.kt
+++ b/mobile/src/main/java/com/example/mymediaplayer/MainScreen.kt
@@ -2226,6 +2226,7 @@ private fun ExpandedNowPlayingDialog(
     } else {
         projectedPositionMs.coerceAtLeast(0L)
     }
+    var isSeeking by remember { mutableStateOf(false) }
     var seekValueMs by remember(
         trackName,
         artistName,
@@ -2235,6 +2236,22 @@ private fun ExpandedNowPlayingDialog(
         isPlaying
     ) {
         mutableStateOf(clampedProjectedMs.toFloat())
+    }
+
+    // Continuously update progress while playing and user is not dragging the slider
+    LaunchedEffect(isPlaying, currentPositionMs, positionUpdatedAtElapsedMs, playbackSpeed) {
+        while (isPlaying && playbackSpeed > 0f) {
+            kotlinx.coroutines.delay(250L)
+            if (!isSeeking) {
+                val elapsed = (SystemClock.elapsedRealtime() - positionUpdatedAtElapsedMs).coerceAtLeast(0L)
+                val projected = currentPositionMs + (elapsed * playbackSpeed).toLong()
+                seekValueMs = if (durationSafe > 0L) {
+                    projected.coerceIn(0L, durationSafe).toFloat()
+                } else {
+                    projected.coerceAtLeast(0L).toFloat()
+                }
+            }
+        }
     }
 
     AlertDialog(
@@ -2258,9 +2275,15 @@ private fun ExpandedNowPlayingDialog(
                 if (durationSafe > 0L) {
                     Slider(
                         value = seekValueMs.coerceIn(0f, durationSafe.toFloat()),
-                        onValueChange = { seekValueMs = it },
+                        onValueChange = {
+                            isSeeking = true
+                            seekValueMs = it
+                        },
                         valueRange = 0f..durationSafe.toFloat(),
-                        onValueChangeFinished = { onSeekTo(seekValueMs.toLong()) }
+                        onValueChangeFinished = {
+                            isSeeking = false
+                            onSeekTo(seekValueMs.toLong())
+                        }
                     )
                     Row(
                         modifier = Modifier.fillMaxWidth(),


### PR DESCRIPTION
## Summary

- Added `LaunchedEffect` to `ExpandedNowPlayingDialog` that updates the slider position every 250ms while playing
- Extrapolates position from `currentPositionMs` + elapsed time (same calculation that already existed but wasn't being fed back to the slider)
- Pauses automatic updates while user is dragging the slider to seek (`isSeeking` flag)

**Root cause:** `seekValueMs` was initialized once in a `remember` block and never updated during continuous playback. The position extrapolation code existed but its result was never assigned back to the slider state.

Closes #62

## Test plan

- [ ] Play a song, open expanded player — progress bar and time should advance smoothly
- [ ] Drag slider to seek — slider should follow your finger without jumping
- [ ] Pause playback — progress should stop advancing
- [ ] Resume — progress should continue from correct position
- [ ] Unit tests: `./gradlew :mobile:testDebugUnitTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)