### PR TITLE
🔒 Fix sensitive data leak in ApiKeyStore exception logging

### DIFF
--- a/shared/src/main/java/com/example/mymediaplayer/shared/ApiKeyStore.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/ApiKeyStore.kt
@@ -145,8 +145,8 @@ object ApiKeyStore {
             EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
             EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
         )
-    }.getOrElse { e ->
-        Log.e(TAG, "Failed to open encrypted prefs — API keys unavailable", e)
+    }.getOrElse { _ ->
+        Log.e(TAG, "Failed to open encrypted prefs — API keys unavailable")
         null
     }
 }


### PR DESCRIPTION
🎯 **What:** The `ApiKeyStore.kt` class was logging the full exception object when `EncryptedSharedPreferences.create` failed.
⚠️ **Risk:** The exception stack trace and message could contain sensitive information, such as file paths, keystore implementation details, or other sensitive system state, which would be visible to other applications or components reading the Android logcat.
🛡️ **Solution:** The log message in the `getOrElse` block has been updated to remove the exception object `e` (renamed to `_`) and print a generic error message instead. This eliminates the vulnerability without impacting functionality, and existing tests verifying failure paths continue to pass.

---
*PR created automatically by Jules for task [1960692199140669540](https://jules.google.com/task/1960692199140669540) started by @kimptoc*