### PR TITLE
🧹 Refactor deeply nested logic in MainActivity into helper functions

### DIFF
--- a/mobile/src/main/java/com/example/mymediaplayer/MainActivity.kt
+++ b/mobile/src/main/java/com/example/mymediaplayer/MainActivity.kt
@@ -448,28 +448,15 @@ class MainActivity : ComponentActivity() {
                     onPlayPlaylist = { playlist ->
                         sendFilesToServiceIfNeeded(uiState.value.scan.scannedFiles)
                         sendPlaylistsToServiceIfNeeded(uiState.value.scan.discoveredPlaylists)
-                        val mediaId = if (playlist.uriString.startsWith(MainViewModel.SMART_PREFIX)) {
-                            val smartId = playlist.uriString.removePrefix(MainViewModel.SMART_PREFIX)
-                            SMART_PLAYLIST_PREFIX + Uri.encode(smartId)
-                        } else {
-                            "playlist:${playlist.uriString}"
-                        }
+                        val mediaId = getPlaylistMediaId(playlist.uriString)
                         mediaController?.transportControls?.playFromMediaId(mediaId, null)
                     },
                     onShufflePlaylistSongs = { playlist, songs ->
                         if (songs.isNotEmpty()) {
                             sendFilesToServiceIfNeeded(uiState.value.scan.scannedFiles)
                             sendPlaylistsToServiceIfNeeded(uiState.value.scan.discoveredPlaylists)
-                            val listKey = if (playlist.uriString.startsWith(MainViewModel.SMART_PREFIX)) {
-                                val smartId = playlist.uriString.removePrefix(MainViewModel.SMART_PREFIX)
-                                SMART_PLAYLIST_PREFIX + Uri.encode(smartId)
-                            } else {
-                                PLAYLIST_URI_PREFIX + Uri.encode(playlist.uriString)
-                            }
-                            mediaController?.transportControls?.playFromMediaId(
-                                ACTION_SHUFFLE_PREFIX + listKey,
-                                null
-                            )
+                            val mediaId = getPlaylistShuffleMediaId(playlist.uriString)
+                            mediaController?.transportControls?.playFromMediaId(mediaId, null)
                         }
                     }
                 )
@@ -963,6 +950,25 @@ class MainActivity : ComponentActivity() {
                     if (lastTrigger > 0L) formatElapsed(lastTrigger) else "n/a"
             )
         }
+    }
+
+    private fun getPlaylistMediaId(uriString: String): String {
+        return if (uriString.startsWith(MainViewModel.SMART_PREFIX)) {
+            val smartId = uriString.removePrefix(MainViewModel.SMART_PREFIX)
+            SMART_PLAYLIST_PREFIX + Uri.encode(smartId)
+        } else {
+            "playlist:$uriString"
+        }
+    }
+
+    private fun getPlaylistShuffleMediaId(uriString: String): String {
+        val listKey = if (uriString.startsWith(MainViewModel.SMART_PREFIX)) {
+            val smartId = uriString.removePrefix(MainViewModel.SMART_PREFIX)
+            SMART_PLAYLIST_PREFIX + Uri.encode(smartId)
+        } else {
+            PLAYLIST_URI_PREFIX + Uri.encode(uriString)
+        }
+        return ACTION_SHUFFLE_PREFIX + listKey
     }
 
     private fun formatElapsed(elapsedMs: Long): String {


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
The `onPlayPlaylist` and `onShufflePlaylistSongs` closures in `MainActivity.kt` contained duplicated and deeply nested logic for calculating media IDs based on smart playlist prefixes.

💡 **Why:** How this improves maintainability
Extracting this logic into `getPlaylistMediaId` and `getPlaylistShuffleMediaId` helper methods reduces nesting within the main compose blocks, making the code much easier to read and maintain, and reducing cognitive overhead when dealing with intent/action dispatch loops.

✅ **Verification:** How you confirmed the change is safe
Ran `./gradlew :mobile:testDebugUnitTest` to ensure no related tests broke. The refactor changes no logic, simply moving it into explicitly named inline-able methods.

✨ **Result:** The improvement achieved
Cleaned up the `MainActivity.kt` closures, resolving the deeply nested logic code health issue while preserving all functionality.

---
*PR created automatically by Jules for task [11387437249113540065](https://jules.google.com/task/11387437249113540065) started by @kimptoc*