### PR TITLE
🧹 [Code Health] Refactor deeply nested lambda in MainScreen

### DIFF
--- a/mobile/src/main/java/com/example/mymediaplayer/MainActivity.kt
+++ b/mobile/src/main/java/com/example/mymediaplayer/MainActivity.kt
@@ -277,19 +277,7 @@ class MainActivity : ComponentActivity() {
                     onChoosePlaylistSaveFolder = {
                         openPlaylistDocumentTree.launch(null)
                     },
-                    onScanWholeDriveWithLimit = { limit ->
-                        if (hasMediaReadPermission()) {
-                            getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
-                                .edit()
-                                .putInt(KEY_SCAN_LIMIT, limit)
-                                .putBoolean(KEY_SCAN_WHOLE_DRIVE, true)
-                                .apply()
-                            viewModel.scanWholeDevice(limit, forceRescan = true)
-                        } else {
-                            pendingWholeDriveScanLimit = limit
-                            requestMediaReadPermission.launch(requiredMediaReadPermission())
-                        }
-                    },
+                    onScanWholeDriveWithLimit = ::handleScanWholeDriveWithLimit,
                     onFileClick = { file ->
                         sendFilesToServiceIfNeeded(uiState.value.scan.scannedFiles)
                         mediaController?.transportControls?.playFromMediaId(file.uriString, null)
@@ -801,6 +789,20 @@ class MainActivity : ComponentActivity() {
         controller.transportControls.playFromSearch(query, extras)
         pendingVoiceSearchQuery = null
         pendingVoiceSearchExtras = null
+    }
+
+    private fun handleScanWholeDriveWithLimit(limit: Int) {
+        if (hasMediaReadPermission()) {
+            getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
+                .edit()
+                .putInt(KEY_SCAN_LIMIT, limit)
+                .putBoolean(KEY_SCAN_WHOLE_DRIVE, true)
+                .apply()
+            viewModel.scanWholeDevice(limit, forceRescan = true)
+        } else {
+            pendingWholeDriveScanLimit = limit
+            requestMediaReadPermission.launch(requiredMediaReadPermission())
+        }
     }
 
     private fun toggleBluetoothAutoPlay() {


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was a deeply nested lambda for `onScanWholeDriveWithLimit` inside the `MainScreen` composable constructor call in `MainActivity.kt`.
💡 **Why:** Flattening deeply nested code makes the `MainScreen` configuration much easier to read and maintain by keeping lambda arguments concise.
✅ **Verification:** Verified by ensuring the code changes exactly matched the logic, using `git diff` for correctness, and running `./gradlew :mobile:test` to confirm no regressions.
✨ **Result:** A flatter, cleaner `MainScreen` setup utilizing a private member function reference.

---
*PR created automatically by Jules for task [811251460184005085](https://jules.google.com/task/811251460184005085) started by @kimptoc*