### PR TITLE
🧹 [Code Health] Refactor playlist ID mapping in MainActivity

### DIFF
--- a/mobile/src/main/java/com/example/mymediaplayer/MainActivity.kt
+++ b/mobile/src/main/java/com/example/mymediaplayer/MainActivity.kt
@@ -448,24 +448,14 @@ class MainActivity : ComponentActivity() {
                     onPlayPlaylist = { playlist ->
                         sendFilesToServiceIfNeeded(uiState.value.scan.scannedFiles)
                         sendPlaylistsToServiceIfNeeded(uiState.value.scan.discoveredPlaylists)
-                        val mediaId = if (playlist.uriString.startsWith(MainViewModel.SMART_PREFIX)) {
-                            val smartId = playlist.uriString.removePrefix(MainViewModel.SMART_PREFIX)
-                            SMART_PLAYLIST_PREFIX + Uri.encode(smartId)
-                        } else {
-                            "playlist:${playlist.uriString}"
-                        }
+                        val mediaId = getPlaylistMediaId(playlist)
                         mediaController?.transportControls?.playFromMediaId(mediaId, null)
                     },
                     onShufflePlaylistSongs = { playlist, songs ->
                         if (songs.isNotEmpty()) {
                             sendFilesToServiceIfNeeded(uiState.value.scan.scannedFiles)
                             sendPlaylistsToServiceIfNeeded(uiState.value.scan.discoveredPlaylists)
-                            val listKey = if (playlist.uriString.startsWith(MainViewModel.SMART_PREFIX)) {
-                                val smartId = playlist.uriString.removePrefix(MainViewModel.SMART_PREFIX)
-                                SMART_PLAYLIST_PREFIX + Uri.encode(smartId)
-                            } else {
-                                PLAYLIST_URI_PREFIX + Uri.encode(playlist.uriString)
-                            }
+                            val listKey = getPlaylistShuffleKey(playlist)
                             mediaController?.transportControls?.playFromMediaId(
                                 ACTION_SHUFFLE_PREFIX + listKey,
                                 null
@@ -1014,4 +1004,21 @@ class MainActivity : ComponentActivity() {
             .apply()
     }
 
+    private fun getPlaylistMediaId(playlist: com.example.mymediaplayer.shared.PlaylistInfo): String {
+        return if (playlist.uriString.startsWith(MainViewModel.SMART_PREFIX)) {
+            val smartId = playlist.uriString.removePrefix(MainViewModel.SMART_PREFIX)
+            SMART_PLAYLIST_PREFIX + Uri.encode(smartId)
+        } else {
+            "playlist:${playlist.uriString}"
+        }
+    }
+
+    private fun getPlaylistShuffleKey(playlist: com.example.mymediaplayer.shared.PlaylistInfo): String {
+        return if (playlist.uriString.startsWith(MainViewModel.SMART_PREFIX)) {
+            val smartId = playlist.uriString.removePrefix(MainViewModel.SMART_PREFIX)
+            SMART_PLAYLIST_PREFIX + Uri.encode(smartId)
+        } else {
+            PLAYLIST_URI_PREFIX + Uri.encode(playlist.uriString)
+        }
+    }
 }


### PR DESCRIPTION
🎯 **What:** Extracted playlist media ID mapping logic into separate helper functions.
💡 **Why:** To improve code maintainability by reducing nesting within the `onPlayPlaylist` and `onShufflePlaylistSongs` composable callbacks.
✅ **Verification:** Ran mobile tests successfully to ensure no regression was introduced.
✨ **Result:** Cleaned up lambda scopes, making the main event handlers easier to read.

---
*PR created automatically by Jules for task [7612645736354638644](https://jules.google.com/task/7612645736354638644) started by @kimptoc*