### PR TITLE
🧹 [code health improvement] Refactor deeply nested and repetitive code in MainViewModel

### DIFF
--- a/mobile/src/main/java/com/example/mymediaplayer/MainViewModel.kt
+++ b/mobile/src/main/java/com/example/mymediaplayer/MainViewModel.kt
@@ -918,15 +918,16 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                     }
                 }
                 mediaCacheService.removePlaylistByUri(playlist.uriString)
+                val isCurrentlySelected = current.playlist.selectedPlaylist?.uriString == playlist.uriString
                 _uiState.value = current.copy(
                     scan = current.scan.copy(discoveredPlaylists = updatedPlaylists),
                     playlist = current.playlist.copy(
-                        selectedPlaylist = if (current.playlist.selectedPlaylist?.uriString == playlist.uriString) {
+                        selectedPlaylist = if (isCurrentlySelected) {
                             null
                         } else {
                             current.playlist.selectedPlaylist
                         },
-                        playlistSongs = if (current.playlist.selectedPlaylist?.uriString == playlist.uriString) {
+                        playlistSongs = if (isCurrentlySelected) {
                             emptyList()
                         } else {
                             current.playlist.playlistSongs


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was a repetitive boolean expression `current.playlist.selectedPlaylist?.uriString == playlist.uriString` in `mobile/src/main/java/com/example/mymediaplayer/MainViewModel.kt`'s `deletePlaylist` method.

💡 **Why:** Evaluating the same conditional check multiple times adds unnecessary verbosity and cognitive load. Extracting the boolean condition into a well-named local variable (`isCurrentlySelected`) flattens the conditional assignments and significantly improves the clarity of the StateFlow `.copy()` update block.

✅ **Verification:**
- Verified no logic was altered (behavior remains identical).
- Confirmed the mobile module test suite passes successfully via `./gradlew :mobile:test`.
- Confirmed local lint warnings are unaffected by the change.

✨ **Result:** The `MainViewModel.kt` code is now cleaner, less repetitive, and easier to read.

---
*PR created automatically by Jules for task [16848229417326409868](https://jules.google.com/task/16848229417326409868) started by @kimptoc*