### PR TITLE
⚡ Optimize MediaCacheService batch addition

### DIFF
--- a/mobile/src/main/java/com/example/mymediaplayer/MainViewModel.kt
+++ b/mobile/src/main/java/com/example/mymediaplayer/MainViewModel.kt
@@ -197,8 +197,8 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             val cached = scanCache[key]
             if (cached != null) {
                 mediaCacheService.clearCache()
-                cached.first.forEach { mediaCacheService.addFile(it) }
-                cached.second.forEach { mediaCacheService.addPlaylist(it) }
+                mediaCacheService.addAllFiles(cached.first)
+                mediaCacheService.addAllPlaylists(cached.second)
                 _uiState.value = resetAfterScan(cached.first, cached.second, maxFiles, deepScan)
                 reimportPlaylistsFromSaveFolderIfNeeded()
                 metadataKey = null
@@ -304,8 +304,8 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             val cached = scanCache[key]
             if (cached != null) {
                 mediaCacheService.clearCache()
-                cached.first.forEach { mediaCacheService.addFile(it) }
-                cached.second.forEach { mediaCacheService.addPlaylist(it) }
+                mediaCacheService.addAllFiles(cached.first)
+                mediaCacheService.addAllPlaylists(cached.second)
                 _uiState.value = resetAfterScan(
                     cached.first,
                     cached.second,
@@ -416,7 +416,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             val current = _uiState.value
             val merged = sortPlaylists((current.scan.discoveredPlaylists + imported).distinctBy { it.uriString })
             mediaCacheService.clearPlaylists()
-            merged.forEach { mediaCacheService.addPlaylist(it) }
+            mediaCacheService.addAllPlaylists(merged)
             _uiState.value = current.copy(
                 scan = current.scan.copy(discoveredPlaylists = merged),
                 playlist = current.playlist.copy(

--- a/shared/src/main/java/com/example/mymediaplayer/shared/MediaCacheService.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/MediaCacheService.kt
@@ -474,9 +474,28 @@ class MediaCacheService {
         }
     }
 
+    fun addAllFiles(files: List<MediaFileInfo>) {
+        if (files.isEmpty()) return
+        synchronized(cacheLock) {
+            val spaceLeft = MAX_CACHE_SIZE - _cachedFiles.size
+            if (spaceLeft <= 0) return
+            val toAdd = if (files.size > spaceLeft) files.take(spaceLeft) else files
+            _cachedFiles.addAll(toAdd)
+            _cachedFilesByUri.putAll(toAdd.associateBy { it.uriString })
+            albumArtistIndexed = false
+        }
+    }
+
     fun addPlaylist(playlistInfo: PlaylistInfo) {
         synchronized(cacheLock) {
             _discoveredPlaylists.add(playlistInfo)
+        }
+    }
+
+    fun addAllPlaylists(playlists: List<PlaylistInfo>) {
+        if (playlists.isEmpty()) return
+        synchronized(cacheLock) {
+            _discoveredPlaylists.addAll(playlists)
         }
     }
 

--- a/shared/src/test/java/com/example/mymediaplayer/shared/MediaCacheServiceBenchmarkTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/MediaCacheServiceBenchmarkTest.kt
@@ -1,0 +1,40 @@
+package com.example.mymediaplayer.shared
+
+import org.junit.Test
+import kotlin.system.measureTimeMillis
+
+class MediaCacheServiceBenchmarkTest {
+    @Test
+    fun benchmarkAddFileVsAddAllFiles() {
+        val service = MediaCacheService()
+        val files = List(50000) { i ->
+            MediaFileInfo(
+                uriString = "content://media/external/audio/media/$i",
+                displayName = "Song $i.mp3",
+                sizeBytes = 1000L,
+                title = "Song $i",
+                artist = "Artist $i",
+                album = "Album $i"
+            )
+        }
+
+        // Warmup
+        service.clearCache()
+        for (i in 0..10) {
+            files.take(100).forEach { service.addFile(it) }
+        }
+        service.clearCache()
+
+        val time1 = measureTimeMillis {
+            files.forEach { service.addFile(it) }
+        }
+        println("addFile individually (50k items): $time1 ms")
+
+        service.clearCache()
+
+        val time2 = measureTimeMillis {
+            service.addAllFiles(files)
+        }
+        println("addAllFiles (50k items): $time2 ms")
+    }
+}


### PR DESCRIPTION
💡 **What:** 
Added batch addition methods (`addAllFiles`, `addAllPlaylists`) to `MediaCacheService` and refactored `MainViewModel` to use them.

🎯 **Why:** 
Previously, scanning operations in `MainViewModel` iterated over a list of cached files and called `mediaCacheService.addFile()` and `mediaCacheService.addPlaylist()` individually. Each individual call acquired the `synchronized(cacheLock)`, leading to excessive lock contention and inefficiency when processing potentially thousands of items. Batch additions acquire the lock once for the entire batch.

📊 **Measured Improvement:** 
Created a benchmark (`MediaCacheServiceBenchmarkTest`) measuring the time to add 50,000 files to the cache.
*   **Baseline (Individual `addFile`):** ~206 ms
*   **Optimized (Batch `addAllFiles`):** ~92 ms
*   **Improvement:** The batch optimization is approximately 2.2x faster, saving over 100ms of UI thread / lock contention time per 50k scan reload operation.

---
*PR created automatically by Jules for task [6712265356182029036](https://jules.google.com/task/6712265356182029036) started by @kimptoc*