### PR TITLE
🧹 [Code Health] Extract `onSaveCloudAnnouncementKeys` logic to a private function

### DIFF
--- a/mobile/src/main/java/com/example/mymediaplayer/MainActivity.kt
+++ b/mobile/src/main/java/com/example/mymediaplayer/MainActivity.kt
@@ -415,26 +415,7 @@ class MainActivity : ComponentActivity() {
                     cloudAnnouncementKiloKey = cloudAnnouncementKiloKey.value,
                     cloudAnnouncementTtsKey = cloudAnnouncementTtsKey.value,
                     onSaveCloudAnnouncementKeys = { kilo, tts, onValidated ->
-                        cloudAnnouncementKiloKey.value = kilo
-                        cloudAnnouncementTtsKey.value = tts
-                        ApiKeyStore.getPrefs(this)
-                            ?.edit()
-                            ?.putString(ApiKeyStore.KEY_KILO, kilo)
-                            ?.putString(ApiKeyStore.KEY_CLOUD_TTS, tts)
-                            ?.apply()
-                        lifecycleScope.launch {
-                            val (kiloResult, ttsResult) = ApiKeyStore.validateKeys(this@MainActivity)
-                            val kiloMsg = when (kiloResult) {
-                                is ApiKeyStore.ValidationResult.Success -> if (kilo.isBlank()) "Kilo API: Anonymous mode" else "Kilo API: OK"
-                                is ApiKeyStore.ValidationResult.Error -> "Kilo API: ${kiloResult.message}"
-                            }
-                            val ttsMsg = when (ttsResult) {
-                                is ApiKeyStore.ValidationResult.Success -> if (tts.isBlank()) "Google TTS: Using on-device" else "Google TTS: OK"
-                                is ApiKeyStore.ValidationResult.Error -> "Google TTS: Not configured (using on-device)"
-                            }
-                            Toast.makeText(this@MainActivity, "$kiloMsg\n$ttsMsg", Toast.LENGTH_LONG).show()
-                            onValidated()
-                        }
+                        handleSaveCloudAnnouncementKeys(kilo, tts, onValidated)
                     },
                     debugCloudAnnouncements = debugCloudAnnouncements.value,
                     onSetDebugCloudAnnouncements = { enabled ->
@@ -777,6 +758,29 @@ class MainActivity : ComponentActivity() {
             putBoolean(EXTRA_TRACK_VOICE_OUTRO_ENABLED, trackVoiceOutroEnabled.value)
         }
         controller.transportControls.sendCustomAction(ACTION_SET_TRACK_VOICE_OUTRO, bundle)
+    }
+
+    private fun handleSaveCloudAnnouncementKeys(kilo: String, tts: String, onValidated: () -> Unit) {
+        cloudAnnouncementKiloKey.value = kilo
+        cloudAnnouncementTtsKey.value = tts
+        ApiKeyStore.getPrefs(this)
+            ?.edit()
+            ?.putString(ApiKeyStore.KEY_KILO, kilo)
+            ?.putString(ApiKeyStore.KEY_CLOUD_TTS, tts)
+            ?.apply()
+        lifecycleScope.launch {
+            val (kiloResult, ttsResult) = ApiKeyStore.validateKeys(this@MainActivity)
+            val kiloMsg = when (kiloResult) {
+                is ApiKeyStore.ValidationResult.Success -> if (kilo.isBlank()) "Kilo API: Anonymous mode" else "Kilo API: OK"
+                is ApiKeyStore.ValidationResult.Error -> "Kilo API: ${kiloResult.message}"
+            }
+            val ttsMsg = when (ttsResult) {
+                is ApiKeyStore.ValidationResult.Success -> if (tts.isBlank()) "Google TTS: Using on-device" else "Google TTS: OK"
+                is ApiKeyStore.ValidationResult.Error -> "Google TTS: Not configured (using on-device)"
+            }
+            Toast.makeText(this@MainActivity, "$kiloMsg\n$ttsMsg", Toast.LENGTH_LONG).show()
+            onValidated()
+        }
     }
 
     private fun sendDebugCloudSettingToService(enabled: Boolean) {


### PR DESCRIPTION
🎯 **What:** The deeply nested logic inside the `onSaveCloudAnnouncementKeys` lambda passed to the `MainScreen` component in `MainActivity` has been extracted to a separate private function named `handleSaveCloudAnnouncementKeys`.

💡 **Why:** Having large chunks of business logic directly within the Jetpack Compose configuration (`setContent` block) hurts readability. By extracting this logic into a dedicated function, the Compose setup remains clean and declarative, making it easier to read and maintain.

✅ **Verification:** Verified the code compiles successfully (`./gradlew :mobile:compileDebugKotlin`), the mobile module tests pass (`./gradlew :mobile:test`), and no new regressions were introduced in lint (`./gradlew lint`). The local `MutableState` properties `cloudAnnouncementKiloKey` and `cloudAnnouncementTtsKey` are defined at the class level in `MainActivity`, ensuring they are fully accessible by the new extracted function without issue.

✨ **Result:** A more readable `MainActivity` setup, cleanly separating the Compose UI structure from the asynchronous logic handling the API key validation and saving.

---
*PR created automatically by Jules for task [2685494181796386516](https://jules.google.com/task/2685494181796386516) started by @kimptoc*