### PR TITLE
🧹 [Refactor] Extract deeply nested onSelectionToggle lambda in MainScreen

### DIFF
--- a/mobile/src/main/java/com/example/mymediaplayer/MainScreen.kt
+++ b/mobile/src/main/java/com/example/mymediaplayer/MainScreen.kt
@@ -488,6 +488,15 @@ fun MainScreen(
                             }
                         }
                     }
+
+                    val handleSearchSelectionToggle: (MediaFileInfo) -> Unit = { file ->
+                        selectedSearchUris = if (file.uriString in selectedSearchUris) {
+                            selectedSearchUris - file.uriString
+                        } else {
+                            selectedSearchUris + file.uriString
+                        }
+                    }
+
                     SongsListSection(
                         title = "Search Results (${visibleSearchResults.size})",
                         songs = visibleSearchResults,
@@ -509,13 +518,7 @@ fun MainScreen(
                         onToggleFavorite = onToggleFavorite,
                         enableSelection = isSearchSelectionMode,
                         selectedUris = selectedSearchUris,
-                        onSelectionToggle = { file ->
-                            selectedSearchUris = if (file.uriString in selectedSearchUris) {
-                                selectedSearchUris - file.uriString
-                            } else {
-                                selectedSearchUris + file.uriString
-                            }
-                        },
+                        onSelectionToggle = handleSearchSelectionToggle,
                         currentMediaId = uiState.playback.currentMediaId
                     )
                 }


### PR DESCRIPTION
🎯 **What:** Extracted the deeply nested `onSelectionToggle` lambda in `MainScreen.kt` into a local variable `handleSearchSelectionToggle`.
💡 **Why:** To improve readability and maintainability by flattening the deeply nested Compose UI structure.
✅ **Verification:** Ran project linting and all tests (`./gradlew :mobile:test` and `./gradlew :shared:test`) to confirm functionality is preserved. Code review approved.
✨ **Result:** Cleaner, more readable code in `MainScreen` without altering the logic.

---
*PR created automatically by Jules for task [7318584599527796929](https://jules.google.com/task/7318584599527796929) started by @kimptoc*