### PR TITLE
🧹 Refactor: Flatten nested code in MainScreen DropdownMenu

### DIFF
--- a/mobile/src/main/java/com/example/mymediaplayer/MainScreen.kt
+++ b/mobile/src/main/java/com/example/mymediaplayer/MainScreen.kt
@@ -248,30 +248,14 @@ fun MainScreen(
                             enabled = uiState.scan.scannedFiles.isNotEmpty()
                         )
                         DropdownMenuItem(
-                            text = {
-                                Text(
-                                    if (trackVoiceIntroEnabled) {
-                                        "Track Voice Intro: On"
-                                    } else {
-                                        "Track Voice Intro: Off"
-                                    }
-                                )
-                            },
+                            text = { Text("Track Voice Intro: ${if (trackVoiceIntroEnabled) "On" else "Off"}") },
                             onClick = {
                                 menuExpanded = false
                                 onToggleTrackVoiceIntro()
                             }
                         )
                         DropdownMenuItem(
-                            text = {
-                                Text(
-                                    if (trackVoiceOutroEnabled) {
-                                        "Track Voice Outro: On"
-                                    } else {
-                                        "Track Voice Outro: Off"
-                                    }
-                                )
-                            },
+                            text = { Text("Track Voice Outro: ${if (trackVoiceOutroEnabled) "On" else "Off"}") },
                             onClick = {
                                 menuExpanded = false
                                 onToggleTrackVoiceOutro()
@@ -285,15 +269,7 @@ fun MainScreen(
                             }
                         )
                         DropdownMenuItem(
-                            text = {
-                                Text(
-                                    if (bluetoothAutoPlayEnabled) {
-                                        "Bluetooth Auto-Play: On"
-                                    } else {
-                                        "Bluetooth Auto-Play: Off"
-                                    }
-                                )
-                            },
+                            text = { Text("Bluetooth Auto-Play: ${if (bluetoothAutoPlayEnabled) "On" else "Off"}") },
                             onClick = {
                                 menuExpanded = false
                                 onToggleBluetoothAutoPlay()


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Deeply nested multiline `if/else` statements within `Text` composables inside the `MainScreen.kt` `DropdownMenu` were hard to read and added unnecessary vertical verbosity.

💡 **Why:** How this improves maintainability
Flattening these nested blocks into single-line string interpolations significantly reduces visual noise and lines of code, making the logic much easier to scan and maintain at a glance.

✅ **Verification:** How you confirmed the change is safe
Ran linting and module unit tests (`./gradlew :mobile:test`) successfully. Since the change is entirely syntactic (string formatting instead of if/else branching within the UI element definition) and does not modify the structure or callbacks of the `DropdownMenuItem` elements, it introduces no risk of functional regressions.

✨ **Result:** The improvement achieved
Reduced deep indentation levels and removed over 20 lines of repetitive structure, replacing them with clean, single-line Kotlin string templates.

---
*PR created automatically by Jules for task [12239052018007084261](https://jules.google.com/task/12239052018007084261) started by @kimptoc*