### PR TITLE
🧹 [Refactor deeply nested event handlers in MainActivity]

### DIFF
--- a/mobile/src/main/java/com/example/mymediaplayer/MainActivity.kt
+++ b/mobile/src/main/java/com/example/mymediaplayer/MainActivity.kt
@@ -277,30 +277,13 @@ class MainActivity : ComponentActivity() {
                     onChoosePlaylistSaveFolder = {
                         openPlaylistDocumentTree.launch(null)
                     },
-                    onScanWholeDriveWithLimit = { limit ->
-                        if (hasMediaReadPermission()) {
-                            getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
-                                .edit()
-                                .putInt(KEY_SCAN_LIMIT, limit)
-                                .putBoolean(KEY_SCAN_WHOLE_DRIVE, true)
-                                .apply()
-                            viewModel.scanWholeDevice(limit, forceRescan = true)
-                        } else {
-                            pendingWholeDriveScanLimit = limit
-                            requestMediaReadPermission.launch(requiredMediaReadPermission())
-                        }
-                    },
+                    onScanWholeDriveWithLimit = { limit -> handleScanWholeDrive(limit) },
                     onFileClick = { file ->
                         sendFilesToServiceIfNeeded(uiState.value.scan.scannedFiles)
                         mediaController?.transportControls?.playFromMediaId(file.uriString, null)
                     },
                     onPlayPause = {
-                        val isPlaying = uiState.value.playback.isPlaying
-                        if (isPlaying) {
-                            mediaController?.transportControls?.pause()
-                        } else {
-                            mediaController?.transportControls?.play()
-                        }
+                        handlePlayPause(uiState.value.playback.isPlaying)
                     },
                     onStop = {
                         mediaController?.transportControls?.stop()
@@ -312,13 +295,7 @@ class MainActivity : ComponentActivity() {
                         mediaController?.transportControls?.skipToPrevious()
                     },
                     onToggleRepeat = {
-                        val current = uiState.value.playback.repeatMode
-                        val next = when (current) {
-                            PlaybackStateCompat.REPEAT_MODE_ALL -> PlaybackStateCompat.REPEAT_MODE_ONE
-                            PlaybackStateCompat.REPEAT_MODE_ONE -> PlaybackStateCompat.REPEAT_MODE_NONE
-                            else -> PlaybackStateCompat.REPEAT_MODE_ALL
-                        }
-                        mediaController?.transportControls?.setRepeatMode(next)
+                        handleToggleRepeat(uiState.value.playback.repeatMode)
                     },
                     onQueueItemSelected = { queueId ->
                         mediaController?.transportControls?.skipToQueueItem(queueId)
@@ -475,6 +452,37 @@ class MainActivity : ComponentActivity() {
                 )
             }
         }
+    }
+
+    private fun handleScanWholeDrive(limit: Int) {
+        if (hasMediaReadPermission()) {
+            getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
+                .edit()
+                .putInt(KEY_SCAN_LIMIT, limit)
+                .putBoolean(KEY_SCAN_WHOLE_DRIVE, true)
+                .apply()
+            viewModel.scanWholeDevice(limit, forceRescan = true)
+        } else {
+            pendingWholeDriveScanLimit = limit
+            requestMediaReadPermission.launch(requiredMediaReadPermission())
+        }
+    }
+
+    private fun handlePlayPause(isPlaying: Boolean) {
+        if (isPlaying) {
+            mediaController?.transportControls?.pause()
+        } else {
+            mediaController?.transportControls?.play()
+        }
+    }
+
+    private fun handleToggleRepeat(current: Int) {
+        val next = when (current) {
+            PlaybackStateCompat.REPEAT_MODE_ALL -> PlaybackStateCompat.REPEAT_MODE_ONE
+            PlaybackStateCompat.REPEAT_MODE_ONE -> PlaybackStateCompat.REPEAT_MODE_NONE
+            else -> PlaybackStateCompat.REPEAT_MODE_ALL
+        }
+        mediaController?.transportControls?.setRepeatMode(next)
     }
 
     private fun observeViewModel() {


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Deeply nested inline lambda blocks within the `MainScreen` composable invocation in `MainActivity.kt` made the initialization logic hard to read and maintain.

💡 **Why:** How this improves maintainability
Extracting complex lambda logic into private class-level helper functions (e.g., `handleToggleRepeat`, `handleScanWholeDrive`) flattens the code structure, isolates event-handling logic, and makes the `MainScreen` parameter list significantly cleaner and easier to parse.

✅ **Verification:** How you confirmed the change is safe
- Verified using `git diff` that no logic was structurally altered, only moved.
- Ensured no local Compose state (like `cloudAnnouncementKiloKey`) was inappropriately captured outside its scope by leaving scoped lambda extractions as inline or properly passing state values.
- Built the application using `./gradlew :mobile:assembleDebug`.
- Ran and passed all mobile module unit tests via `./gradlew :mobile:test`.

✨ **Result:** The improvement achieved
The `MainActivity.kt` initialization block is cleaner, more declarative, and easier to modify in the future, successfully addressing the deep nesting issue identified at line 316.

---
*PR created automatically by Jules for task [10620415188439357810](https://jules.google.com/task/10620415188439357810) started by @kimptoc*