### PR TITLE
🧹 [Code Health] Remove unused assertNotNull import in MediaItemBuildersTest

### DIFF
--- a/shared/src/test/java/com/example/mymediaplayer/shared/MediaItemBuildersTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/MediaItemBuildersTest.kt
@@ -3,7 +3,6 @@ package com.example.mymediaplayer.shared
 import android.net.Uri
 import android.support.v4.media.MediaBrowserCompat.MediaItem
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith


### PR DESCRIPTION
* 🎯 **What:** Removed unused `import org.junit.Assert.assertNotNull` from `shared/src/test/java/com/example/mymediaplayer/shared/MediaItemBuildersTest.kt`.
* 💡 **Why:** Reduces clutter and improves maintainability by removing dead code.
* ✅ **Verification:** Ran `./gradlew :shared:testDebugUnitTest --tests '*MediaItemBuildersTest*'` and `./gradlew :shared:lintDebug`.
* ✨ **Result:** Cleaner codebase without any behavior changes.

---
*PR created automatically by Jules for task [9414132596761955785](https://jules.google.com/task/9414132596761955785) started by @kimptoc*