### PR TITLE
🧹 [code health] Remove unused resolveSmartPlaylistTracks method

### DIFF
--- a/shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
@@ -2317,11 +2317,6 @@ class MyMusicService : MediaBrowserServiceCompat() {
         return smartPlaylistTitleFromId(smartId)
     }
 
-    private fun resolveSmartPlaylistTracks(playlistNameQuery: String): List<MediaFileInfo>? {
-        val smartId = smartPlaylistIdFromQuery(playlistNameQuery) ?: return null
-        return resolveSmartPlaylistTracksById(smartId)
-    }
-
     @VisibleForTesting
     internal fun smartPlaylistIdFromQuery(query: String): String? {
         val needle = query.lowercase().trim()


### PR DESCRIPTION
🎯 **What:** Removed unused `resolveSmartPlaylistTracks` method from `MyMusicService.kt`.
💡 **Why:** This method is dead code and never called. Removing it improves maintainability and readability by reducing clutter.
✅ **Verification:** Ran `shared` tests and linting to ensure no functionality is broken and no regressions occurred.
✨ **Result:** A cleaner `MyMusicService.kt` file.

---
*PR created automatically by Jules for task [17210695614676596790](https://jules.google.com/task/17210695614676596790) started by @kimptoc*