### PR TITLE
🔒 Security: Prevent logging full Kilo API error responses

### DIFF
--- a/shared/src/main/java/com/example/mymediaplayer/shared/AnnouncementPreGenerator.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/AnnouncementPreGenerator.kt
@@ -238,8 +238,7 @@ internal class AnnouncementPreGenerator(
 
             val responseCode = conn.responseCode
             if (responseCode != 200) {
-                val errorBody = conn.errorStream?.bufferedReader()?.readText() ?: "no error body"
-                Log.w(TAG, "Kilo HTTP $responseCode: $errorBody")
+                Log.w(TAG, "Kilo HTTP $responseCode: API request failed")
                 return@withContext null
             }
 


### PR DESCRIPTION
🎯 **What:** The `AnnouncementPreGenerator` was previously reading the full API error body from `conn.errorStream` and writing it directly to Android system logs. This behavior has been removed and replaced with a generic log message.

⚠️ **Risk:** Logging full API error responses exposes the application to Information Exposure vulnerabilities. If the API returns sensitive internal server details, stack traces, or if an attacker can manipulate the API to return a malicious payload, this data would be leaked into the device logs, potentially leading to privilege escalation, data breaches, or log poisoning.

🛡️ **Solution:** The log statement was modified to only output the HTTP status code along with a generic "API request failed" message. The logic that reads the `errorStream` was completely removed, ensuring no external, potentially harmful data is ingested into the logging framework.

---
*PR created automatically by Jules for task [12618135218857335409](https://jules.google.com/task/12618135218857335409) started by @kimptoc*