### PR TITLE
🧪 Add Error Path Test for AnnouncementPreGenerator Timeout

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,6 +44,7 @@ androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = 
 androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }
+kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
 androidx-car-app = { group = "androidx.car.app", name = "app", version.ref = "carApp" }
 androidx-car-app-projected = { group = "androidx.car.app", name = "app-projected", version.ref = "carApp" }
 androidx-test-core = { group = "androidx.test", name = "core", version.ref = "androidxTestCore" }

--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -33,4 +33,5 @@ dependencies {
     testImplementation libs.androidx.test.core
     testImplementation libs.robolectric
     testImplementation libs.kotlinx.coroutines.core
+    testImplementation libs.kotlinx.coroutines.test
 }

--- a/shared/src/test/java/com/example/mymediaplayer/shared/AnnouncementPreGeneratorTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/AnnouncementPreGeneratorTest.kt
@@ -1,0 +1,75 @@
+package com.example.mymediaplayer.shared
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.File
+import kotlinx.coroutines.async
+import java.util.concurrent.ConcurrentHashMap
+import org.robolectric.annotation.Config
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class AnnouncementPreGeneratorTest {
+
+    private lateinit var context: Context
+    private lateinit var preGenerator: AnnouncementPreGenerator
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val testScope = TestScope(testDispatcher)
+
+    @Before
+    fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+        preGenerator = AnnouncementPreGenerator(context, testScope)
+    }
+
+    @Test
+    fun getReadyAudio_timeout_returnsNull() = testScope.runTest {
+        val track = MediaFileInfo(
+            uriString = "content://media/external/audio/media/1",
+            displayName = "test.mp3",
+            sizeBytes = 1000L,
+            title = "Test Song",
+            artist = "Test Artist",
+            album = "Test Album",
+            durationMs = 3000L
+        )
+
+        // Use reflection to access the cache and CacheKey constructor
+        val cacheField = AnnouncementPreGenerator::class.java.getDeclaredField("cache")
+        cacheField.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        val cache = cacheField.get(preGenerator) as ConcurrentHashMap<Any, Any>
+
+        val cacheKeyClass = Class.forName("com.example.mymediaplayer.shared.AnnouncementPreGenerator\$CacheKey")
+        val cacheKeyConstructor = cacheKeyClass.getDeclaredConstructors().first()
+        cacheKeyConstructor.isAccessible = true
+        val key = cacheKeyConstructor.newInstance(track.uriString, true)
+
+        val deferred = async {
+            delay(10_000L) // Longer than READY_TIMEOUT_MS
+            File("test.mp3")
+        }
+
+        cache[key] = deferred
+
+        // Assert timeout happens and null is returned
+        val result = preGenerator.getReadyAudio(track, true)
+
+        // Timeout is 5000ms, the coroutine framework using runTest handles time virtually.
+        assertNull("Expected null due to timeout", result)
+
+        deferred.cancel()
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR introduces a unit test to cover the `TimeoutCancellationException` error path in the `AnnouncementPreGenerator.getReadyAudio` method, which occurs when pre-generating an announcement exceeds the `READY_TIMEOUT_MS` threshold.

📊 **Coverage:** What scenarios are now tested
The `getReadyAudio_timeout_returnsNull` test uses `kotlinx-coroutines-test` features like `runTest` and `TestScope` alongside virtual time to simulate a long-running pre-generation task using `delay(10_000L)`. It validates that when the task exceeds the set timeout limit, the method catches the exception and gracefully returns `null`.

✨ **Result:** The improvement in test coverage
Error path for timeout failures during pre-generation is now fully covered and automatically verified on each CI build, increasing the overall reliability of the feature without impacting the real time test suite execution duration.

---
*PR created automatically by Jules for task [9576820347495737165](https://jules.google.com/task/9576820347495737165) started by @kimptoc*