### PR TITLE
🔒 Fix API Error Response Exposure

### DIFF
--- a/shared/src/main/java/com/example/mymediaplayer/shared/AnnouncementPreGenerator.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/AnnouncementPreGenerator.kt
@@ -238,8 +238,7 @@ internal class AnnouncementPreGenerator(
 
             val responseCode = conn.responseCode
             if (responseCode != 200) {
-                val errorBody = conn.errorStream?.bufferedReader()?.readText() ?: "no error body"
-                Log.w(TAG, "Kilo HTTP $responseCode: $errorBody")
+                Log.w(TAG, "Kilo HTTP $responseCode: API request failed")
                 return@withContext null
             }
 

--- a/shared/src/main/java/com/example/mymediaplayer/shared/ApiKeyStore.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/ApiKeyStore.kt
@@ -85,8 +85,7 @@ object ApiKeyStore {
             OutputStreamWriter(conn.outputStream).use { it.write(body) }
 
             if (conn.responseCode != 200) {
-                val errorBody = conn.errorStream?.bufferedReader()?.readText() ?: ""
-                return@withContext ValidationResult.Error("HTTP ${conn.responseCode}: $errorBody")
+                return@withContext ValidationResult.Error("HTTP ${conn.responseCode}: API request failed")
             }
 
             ValidationResult.Success
@@ -119,8 +118,7 @@ object ApiKeyStore {
             OutputStreamWriter(conn.outputStream).use { it.write(body) }
 
             if (conn.responseCode != 200) {
-                val errorBody = conn.errorStream?.bufferedReader()?.readText() ?: ""
-                return@withContext ValidationResult.Error("HTTP ${conn.responseCode}: $errorBody")
+                return@withContext ValidationResult.Error("HTTP ${conn.responseCode}: API request failed")
             }
 
             ValidationResult.Success


### PR DESCRIPTION
🎯 **What:** Removed logging and returning of full API error response bodies (via `conn.errorStream`) in `ApiKeyStore.kt` and `AnnouncementPreGenerator.kt`. Replaced them with generic HTTP status code messages.
⚠️ **Risk:** Logging or returning the full error response body from an external API (like Google TTS or Kilo) can leak sensitive information or expose the system to malicious payloads if the error body is unexpectedly large or malformed.
🛡️ **Solution:** Replaced the detailed error body reads with safe, generic messages such as `"HTTP ${conn.responseCode}: API request failed"`.
✅ **Verification:** Ran `./gradlew :shared:testDebugUnitTest` and `./gradlew :shared:lintDebug` to ensure existing functionality remains intact and no new lint errors were introduced. Checked the code manually to verify no sensitive data is read from `errorStream`.
✨ **Result:** Enhanced security by preventing potential data leakage and ensuring only safe, generic HTTP status errors are bubbled up or logged.

---
*PR created automatically by Jules for task [16625937908126409072](https://jules.google.com/task/16625937908126409072) started by @kimptoc*