### PR TITLE
🔒 Fix: Prevent API Error Responses Exposure in Validation Results

### DIFF
--- a/shared/src/main/java/com/example/mymediaplayer/shared/ApiKeyStore.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/ApiKeyStore.kt
@@ -85,8 +85,7 @@ object ApiKeyStore {
             OutputStreamWriter(conn.outputStream).use { it.write(body) }
 
             if (conn.responseCode != 200) {
-                val errorBody = conn.errorStream?.bufferedReader()?.readText() ?: ""
-                return@withContext ValidationResult.Error("HTTP ${conn.responseCode}: $errorBody")
+                return@withContext ValidationResult.Error("HTTP ${conn.responseCode}: API request failed")
             }
 
             ValidationResult.Success
@@ -119,8 +118,7 @@ object ApiKeyStore {
             OutputStreamWriter(conn.outputStream).use { it.write(body) }
 
             if (conn.responseCode != 200) {
-                val errorBody = conn.errorStream?.bufferedReader()?.readText() ?: ""
-                return@withContext ValidationResult.Error("HTTP ${conn.responseCode}: $errorBody")
+                return@withContext ValidationResult.Error("HTTP ${conn.responseCode}: API request failed")
             }
 
             ValidationResult.Success


### PR DESCRIPTION
🎯 **What:** Removed logging of raw API error response body from `ApiKeyStore.kt` validation results.
⚠️ **Risk:** Including the full error body could potentially expose sensitive information from the external API to system logs or UI, depending on how `ValidationResult.Error` is consumed.
🛡️ **Solution:** Replaced the detailed error body read with a generic error message indicating only the HTTP response code.
✅ **Verification:** Unit tests and lint were run.
✨ **Result:** Prevents raw external service responses from bubbling up and possibly leaking or providing attack vectors.

---
*PR created automatically by Jules for task [12680275865539937383](https://jules.google.com/task/12680275865539937383) started by @kimptoc*