### PR TITLE
Refactor SmartPlaylistBenchmarkTest to avoid reflection

### DIFF
--- a/shared/src/main/java/com/example/mymediaplayer/shared/MediaCacheService.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/MediaCacheService.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.net.Uri
 import android.provider.DocumentsContract
 import android.provider.MediaStore
+import androidx.annotation.VisibleForTesting
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -464,6 +465,7 @@ class MediaCacheService {
         dao.replaceCache(files, playlists, state)
     }
 
+    @VisibleForTesting
     fun addFile(fileInfo: MediaFileInfo) {
         synchronized(cacheLock) {
             if (_cachedFiles.size < MAX_CACHE_SIZE) {
@@ -684,6 +686,7 @@ class MediaCacheService {
         return displayName.substring(dot).lowercase(Locale.US)
     }
 
+    @VisibleForTesting
     fun clearFiles() {
         synchronized(cacheLock) {
             _cachedFiles.clear()

--- a/shared/src/test/java/com/example/mymediaplayer/shared/SmartPlaylistBenchmarkTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/SmartPlaylistBenchmarkTest.kt
@@ -44,14 +44,10 @@ class SmartPlaylistBenchmarkTest {
         }
 
         // Fix for adding files directly to cachedFiles variable since we cannot set cachedFiles (it has a private setter in Kotlin)
-        val methodClear = MediaCacheService::class.java.getDeclaredMethod("clearFiles")
-        methodClear.isAccessible = true
-        methodClear.invoke(mediaCacheService)
+        mediaCacheService.clearFiles()
 
-        val methodAdd = MediaCacheService::class.java.getDeclaredMethod("addFile", MediaFileInfo::class.java)
-        methodAdd.isAccessible = true
         for (file in files) {
-             methodAdd.invoke(mediaCacheService, file)
+             mediaCacheService.addFile(file)
         }
 
         // To access getSharedPreferences in MyMusicService we need a Context.


### PR DESCRIPTION
🎯 **What:** Modified `SmartPlaylistBenchmarkTest.kt` to call `clearFiles` and `addFile` methods on `MediaCacheService` directly instead of via reflection. Added `@VisibleForTesting` to these methods in `MediaCacheService.kt` to document this intended test usage.
💡 **Why:** Reflection is slow, brittle, and harder to maintain in tests. Exposing these methods through the `@VisibleForTesting` test seam makes the test code clearer and less prone to breaking if method signatures change internally.
✅ **Verification:** Verified that `./gradlew :shared:testDebugUnitTest` passes entirely without regressions and that `./gradlew :shared:lintDebug` reports no issues.
✨ **Result:** Test code is now more robust and no longer dependent on reflection for initializing the test cache state.

---
*PR created automatically by Jules for task [1808220213214828633](https://jules.google.com/task/1808220213214828633) started by @kimptoc*