### PR TITLE
🧹 [Code Health] Refactor MainViewModel to extract scan message formatting

### DIFF
--- a/mobile/src/main/java/com/example/mymediaplayer/MainViewModel.kt
+++ b/mobile/src/main/java/com/example/mymediaplayer/MainViewModel.kt
@@ -261,31 +261,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             if (!deepScan) {
                 mediaCacheService.persistCache(getApplication(), treeUri, maxFiles)
             }
-            val seconds = stats.durationMs / 1000.0
-            val typeSummary = stats.extensionCounts.entries
-                .sortedByDescending { it.value }
-                .take(5)
-                .joinToString(", ") { "${it.key}:${it.value}" }
-                .ifBlank { "n/a" }
-            val skipSummary = if (stats.skippedReasons.isEmpty()) {
-                "none"
-            } else {
-                stats.skippedReasons.entries
-                    .sortedByDescending { it.value }
-                    .take(3)
-                    .joinToString(", ") { "${it.key}:${it.value}" }
-            }
-            val modeLabel = if (stats.deepScan) "Deep" else "Normal"
-            val message =
-                "$modeLabel scan complete in %.1fs • Folders: %d • Songs: %d • Types: %s • Skipped: %s • Probed: %d"
-                    .format(
-                        seconds,
-                        stats.foldersScanned,
-                        stats.songsFound,
-                        typeSummary,
-                        skipSummary,
-                        stats.probedCandidates
-                    )
+            val message = formatDirectoryScanMessage(stats)
             _uiState.value = resetAfterScan(
                 files,
                 playlists,
@@ -376,15 +352,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                 MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
                 maxFiles
             )
-            val seconds = stats.durationMs / 1000.0
-            val typeSummary = stats.extensionCounts.entries
-                .sortedByDescending { it.value }
-                .take(5)
-                .joinToString(", ") { "${it.key}:${it.value}" }
-                .ifBlank { "n/a" }
-            val message =
-                "Whole-drive scan complete in %.1fs • Songs: %d • Types: %s"
-                    .format(seconds, stats.songsFound, typeSummary)
+            val message = formatWholeDeviceScanMessage(stats)
             _uiState.value = resetAfterScan(
                 files,
                 playlists,
@@ -395,6 +363,44 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             reimportPlaylistsFromSaveFolderIfNeeded()
             metadataKey = null
         }
+    }
+
+    private fun formatDirectoryScanMessage(stats: com.example.mymediaplayer.shared.ScanStats): String {
+        val seconds = stats.durationMs / 1000.0
+        val typeSummary = stats.extensionCounts.entries
+            .sortedByDescending { it.value }
+            .take(5)
+            .joinToString(", ") { "${it.key}:${it.value}" }
+            .ifBlank { "n/a" }
+        val skipSummary = if (stats.skippedReasons.isEmpty()) {
+            "none"
+        } else {
+            stats.skippedReasons.entries
+                .sortedByDescending { it.value }
+                .take(3)
+                .joinToString(", ") { "${it.key}:${it.value}" }
+        }
+        val modeLabel = if (stats.deepScan) "Deep" else "Normal"
+        return "$modeLabel scan complete in %.1fs • Folders: %d • Songs: %d • Types: %s • Skipped: %s • Probed: %d"
+            .format(
+                seconds,
+                stats.foldersScanned,
+                stats.songsFound,
+                typeSummary,
+                skipSummary,
+                stats.probedCandidates
+            )
+    }
+
+    private fun formatWholeDeviceScanMessage(stats: com.example.mymediaplayer.shared.ScanStats): String {
+        val seconds = stats.durationMs / 1000.0
+        val typeSummary = stats.extensionCounts.entries
+            .sortedByDescending { it.value }
+            .take(5)
+            .joinToString(", ") { "${it.key}:${it.value}" }
+            .ifBlank { "n/a" }
+        return "Whole-drive scan complete in %.1fs • Songs: %d • Types: %s"
+            .format(seconds, stats.songsFound, typeSummary)
     }
 
     fun setTreeUri(uri: Uri) {


### PR DESCRIPTION
🎯 **What:** Extracted the scan message formatting logic from `onDirectorySelected` and `scanWholeDevice` into separate private helper functions (`formatDirectoryScanMessage` and `formatWholeDeviceScanMessage`) in `MainViewModel`.
💡 **Why:** Reduces the deep nesting and complexity of the scan functions, making the code more readable and easier to maintain.
✅ **Verification:** Verified by running the module tests (`./gradlew :mobile:testDebugUnitTest`) and lint checks (`./gradlew :mobile:lintDebug`), ensuring all tests pass.
✨ **Result:** Improved readability and adherence to the Single Responsibility Principle without altering existing functionality.

---
*PR created automatically by Jules for task [1163339785512670565](https://jules.google.com/task/1163339785512670565) started by @kimptoc*