### PR TITLE
Add Reggae as a top-level genre bucket

### DIFF
--- a/shared/src/main/java/com/example/mymediaplayer/shared/GenreBuckets.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/GenreBuckets.kt
@@ -58,7 +58,7 @@ fun bucketGenre(raw: String?): String {
             normalized.contains("salsa") || normalized.contains("bachata") ||
             normalized.contains("afrobeat") -> "Latin"
         normalized.contains("reggae") || normalized.contains("dancehall") ||
-            normalized.contains("ska") || normalized.contains("dub") -> "Reggae"
+            normalized.contains("ska") || normalized == "dub" -> "Reggae"
         normalized.contains("soundtrack") || normalized.contains("score") ||
             normalized.contains("ost") || normalized.contains("musical") ||
             normalized.contains("spoken") || normalized.contains("podcast") ||

--- a/shared/src/test/java/com/example/mymediaplayer/shared/GenreBucketsTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/GenreBucketsTest.kt
@@ -19,6 +19,8 @@ class GenreBucketsTest {
         assertEquals("Reggae", bucketGenre("Reggae"))
         assertEquals("Reggae", bucketGenre("Dancehall"))
         assertEquals("Reggae", bucketGenre("Ska"))
+        assertEquals("Reggae", bucketGenre("Dub"))
+        assertEquals("Other", bucketGenre("Dub Techno"))
         assertEquals("Other", bucketGenre("Post-Blackgaze-Experimental"))
         assertEquals("Other", bucketGenre(null))
     }


### PR DESCRIPTION
Moves reggae, dancehall, ska, and dub out of the Latin bucket into
their own Reggae bucket. Keeps reggaeton in Latin by checking Latin
first. Moves afrobeat to Latin where it fits better.

Fixes #114

https://claude.ai/code/session_01KSmfJfRkGXmPj63E8sdNi1