### PR TITLE
Move search bar into TopAppBar

### DIFF
--- a/mobile/src/main/java/com/example/mymediaplayer/MainScreen.kt
+++ b/mobile/src/main/java/com/example/mymediaplayer/MainScreen.kt
@@ -156,7 +156,7 @@ fun MainScreen(
     var showExpandedNowPlayingDialog by remember { mutableStateOf(false) }
     var songsFavoritesOnly by rememberSaveable { mutableStateOf(false) }
     var searchFavoritesOnly by rememberSaveable { mutableStateOf(false) }
-    var isSearchExpanded by remember { mutableStateOf(false) }
+    var isSearchExpanded by rememberSaveable { mutableStateOf(false) }
 
     LaunchedEffect(uiState.search.searchQuery) {
         if (uiState.search.searchQuery.isNotBlank()) {
@@ -260,38 +260,38 @@ fun MainScreen(
                                 TextButton(onClick = { menuExpanded = true }) {
                                     Text("Menu")
                                 }
+                                DropdownMenu(
+                                    expanded = menuExpanded,
+                                    onDismissRequest = { menuExpanded = false }
+                                ) {
+                                    DropdownMenuItem(
+                                        text = { Text("Select Folder") },
+                                        onClick = {
+                                            menuExpanded = false
+                                            scanCountText = uiState.scan.lastScanLimit.toString()
+                                            scanDeepMode = uiState.scan.deepScanEnabled
+                                            showScanDialog = true
+                                        }
+                                    )
+                                    DropdownMenuItem(
+                                        text = { Text("Create Random Playlist") },
+                                        onClick = {
+                                            menuExpanded = false
+                                            playlistCountText = uiState.playlist.lastPlaylistCount.toString()
+                                            showPlaylistDialog = true
+                                        },
+                                        enabled = uiState.scan.scannedFiles.isNotEmpty()
+                                    )
+                                    DropdownMenuItem(
+                                        text = { Text("Settings") },
+                                        onClick = {
+                                            menuExpanded = false
+                                            onOpenSettings()
+                                        }
+                                    )
+                                }
                             } else if (uiState.search.searchQuery.isNotEmpty()) {
                                 TextButton(onClick = onClearSearch) { Text("Clear") }
-                            }
-                            DropdownMenu(
-                                expanded = menuExpanded,
-                                onDismissRequest = { menuExpanded = false }
-                            ) {
-                                DropdownMenuItem(
-                                    text = { Text("Select Folder") },
-                                    onClick = {
-                                        menuExpanded = false
-                                        scanCountText = uiState.scan.lastScanLimit.toString()
-                                        scanDeepMode = uiState.scan.deepScanEnabled
-                                        showScanDialog = true
-                                    }
-                                )
-                                DropdownMenuItem(
-                                    text = { Text("Create Random Playlist") },
-                                    onClick = {
-                                        menuExpanded = false
-                                        playlistCountText = uiState.playlist.lastPlaylistCount.toString()
-                                        showPlaylistDialog = true
-                                    },
-                                    enabled = uiState.scan.scannedFiles.isNotEmpty()
-                                )
-                                DropdownMenuItem(
-                                    text = { Text("Settings") },
-                                    onClick = {
-                                        menuExpanded = false
-                                        onOpenSettings()
-                                    }
-                                )
                             }
                         }
                     )

--- a/mobile/src/main/java/com/example/mymediaplayer/MainScreen.kt
+++ b/mobile/src/main/java/com/example/mymediaplayer/MainScreen.kt
@@ -156,6 +156,13 @@ fun MainScreen(
     var showExpandedNowPlayingDialog by remember { mutableStateOf(false) }
     var songsFavoritesOnly by rememberSaveable { mutableStateOf(false) }
     var searchFavoritesOnly by rememberSaveable { mutableStateOf(false) }
+    var isSearchExpanded by remember { mutableStateOf(false) }
+
+    LaunchedEffect(uiState.search.searchQuery) {
+        if (uiState.search.searchQuery.isNotBlank()) {
+            isSearchExpanded = true
+        }
+    }
 
     LaunchedEffect(uiState.search.searchQuery, uiState.search.searchResults) {
         selectedSearchUris = selectedSearchUris.intersect(uiState.search.searchResults.map { it.uriString }.toSet())
@@ -219,10 +226,42 @@ fun MainScreen(
             ) {
                 Column {
                     TopAppBar(
-                        title = { Text("MyMediaPlayer") },
+                        title = {
+                            if (isSearchExpanded) {
+                                TextField(
+                                    value = uiState.search.searchQuery,
+                                    onValueChange = onSearchQueryChanged,
+                                    placeholder = { Text("Search title, artist, album, genre", color = MaterialTheme.colorScheme.onSurfaceVariant) },
+                                    singleLine = true,
+                                    modifier = Modifier.fillMaxWidth(),
+                                    colors = TextFieldDefaults.colors(
+                                        focusedIndicatorColor = MaterialTheme.colorScheme.primary,
+                                        unfocusedIndicatorColor = MaterialTheme.colorScheme.outline,
+                                        cursorColor = MaterialTheme.colorScheme.primary,
+                                        focusedContainerColor = MaterialTheme.colorScheme.surface,
+                                        unfocusedContainerColor = MaterialTheme.colorScheme.surface
+                                    )
+                                )
+                            } else {
+                                Text("MyMediaPlayer")
+                            }
+                        },
+                        navigationIcon = {
+                            if (isSearchExpanded) {
+                                TextButton(onClick = {
+                                    isSearchExpanded = false
+                                    onClearSearch()
+                                }) { Text("Back") }
+                            }
+                        },
                         actions = {
-                            TextButton(onClick = { menuExpanded = true }) {
-                                Text("Menu")
+                            if (!isSearchExpanded) {
+                                TextButton(onClick = { isSearchExpanded = true }) { Text("Search") }
+                                TextButton(onClick = { menuExpanded = true }) {
+                                    Text("Menu")
+                                }
+                            } else if (uiState.search.searchQuery.isNotEmpty()) {
+                                TextButton(onClick = onClearSearch) { Text("Clear") }
                             }
                             DropdownMenu(
                                 expanded = menuExpanded,
@@ -303,32 +342,6 @@ fun MainScreen(
                         style = MaterialTheme.typography.bodySmall,
                         modifier = Modifier.align(Alignment.CenterHorizontally)
                     )
-                }
-            }
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                TextField(
-                    value = uiState.search.searchQuery,
-                    onValueChange = onSearchQueryChanged,
-                    placeholder = { Text("Search title, artist, album, genre", color = MaterialTheme.colorScheme.onSurfaceVariant) },
-                    singleLine = true,
-                    modifier = Modifier.weight(1f),
-                    colors = TextFieldDefaults.colors(
-                        focusedIndicatorColor = MaterialTheme.colorScheme.primary,
-                        unfocusedIndicatorColor = MaterialTheme.colorScheme.outline,
-                        cursorColor = MaterialTheme.colorScheme.primary,
-                        focusedContainerColor = MaterialTheme.colorScheme.surface,
-                        unfocusedContainerColor = MaterialTheme.colorScheme.surface
-                    )
-                )
-                if (uiState.search.searchQuery.isNotEmpty()) {
-                    TextButton(onClick = onClearSearch) {
-                        Text("Clear")
-                    }
                 }
             }
 


### PR DESCRIPTION
## Summary
- Move search from inline content area to a collapsible search field in the TopAppBar
- Tapping "Search" transforms the app bar into a search input
- Search is always accessible regardless of scroll position
- Auto-expands when query is restored (e.g. after config change)

## Test plan
- [ ] Verify "Search" button appears in TopAppBar
- [ ] Tap Search, verify TextField appears with Back and Clear buttons
- [ ] Type a query, verify search results appear below tabs
- [ ] Tap Back, verify search collapses and query clears
- [ ] Tap Clear, verify query clears but search stays expanded
- [ ] Verify Menu button and dropdown still work when search is collapsed

🤖 Generated with [Claude Code](https://claude.com/claude-code)