### PR TITLE
Convert playlists to list-detail navigation

### DIFF
--- a/mobile/src/main/java/com/example/mymediaplayer/MainScreen.kt
+++ b/mobile/src/main/java/com/example/mymediaplayer/MainScreen.kt
@@ -1672,7 +1672,6 @@ private fun PlaylistsSection(
     var dedupeOnSave by remember(selectedPlaylist?.uriString) { mutableStateOf(false) }
     var editSearchQuery by remember(selectedPlaylist?.uriString) { mutableStateOf("") }
     var showDiscardChangesDialog by remember(selectedPlaylist?.uriString) { mutableStateOf(false) }
-    var pendingSelectPlaylist by remember(selectedPlaylist?.uriString) { mutableStateOf<PlaylistInfo?>(null) }
     var pendingClearSelection by remember(selectedPlaylist?.uriString) { mutableStateOf(false) }
     val dragSwapThresholdPx = with(androidx.compose.ui.platform.LocalDensity.current) { 56.dp.toPx() }
     LaunchedEffect(selectedPlaylist?.uriString, playlistSongs, isEditing) {
@@ -1717,7 +1716,6 @@ private fun PlaylistsSection(
                 TextButton(
                 onClick = {
                     if (hasUnsavedChanges) {
-                        pendingSelectPlaylist = null
                         pendingClearSelection = true
                         showDiscardChangesDialog = true
                     } else {
@@ -1964,12 +1962,9 @@ private fun PlaylistsSection(
                         editableSongs = playlistSongs
                         dedupeOnSave = false
                         editSearchQuery = ""
-                        val nextSelection = pendingSelectPlaylist
                         val clearSelection = pendingClearSelection
-                        pendingSelectPlaylist = null
                         pendingClearSelection = false
                         if (clearSelection) onClearPlaylistSelection()
-                        if (nextSelection != null) onPlaylistSelected(nextSelection)
                     }
                 ) {
                     Text("Discard", color = MaterialTheme.colorScheme.error)
@@ -1979,7 +1974,6 @@ private fun PlaylistsSection(
                 TextButton(
                     onClick = {
                         showDiscardChangesDialog = false
-                        pendingSelectPlaylist = null
                         pendingClearSelection = false
                     }
                 ) {

--- a/mobile/src/main/java/com/example/mymediaplayer/MainScreen.kt
+++ b/mobile/src/main/java/com/example/mymediaplayer/MainScreen.kt
@@ -1689,51 +1689,32 @@ private fun PlaylistsSection(
         return
     }
 
-    Surface(
-        color = MaterialTheme.colorScheme.secondaryContainer,
-        modifier = Modifier.fillMaxWidth()
-    ) {
-        LazyColumn(modifier = Modifier.padding(8.dp)) {
-            val visiblePlaylists = if (selectedPlaylist == null) {
-                playlists
-            } else {
-                playlists.filter { it.uriString == selectedPlaylist.uriString }
-            }
-            items(visiblePlaylists) { playlist ->
-                val isSmart = playlist.uriString.startsWith(MainViewModel.SMART_PREFIX)
-                PlaylistCard(
-                    playlist = playlist,
-                    isCompact = selectedPlaylist != null,
-                    isSmart = isSmart,
-                    onRename = { if (!isSmart) onRequestRenamePlaylist(playlist) },
-                    onDelete = { if (!isSmart) onRequestDeletePlaylist(playlist) },
-                    onClick = {
-                        if (hasUnsavedChanges && selectedPlaylist?.uriString != playlist.uriString) {
-                            pendingSelectPlaylist = playlist
-                            pendingClearSelection = false
-                            showDiscardChangesDialog = true
-                        } else {
-                            onPlaylistSelected(playlist)
-                        }
-                    }
-                )
+    if (selectedPlaylist == null) {
+        Surface(
+            color = MaterialTheme.colorScheme.secondaryContainer,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            LazyColumn(modifier = Modifier.padding(8.dp)) {
+                items(playlists) { playlist ->
+                    val isSmart = playlist.uriString.startsWith(MainViewModel.SMART_PREFIX)
+                    PlaylistCard(
+                        playlist = playlist,
+                        isCompact = false,
+                        isSmart = isSmart,
+                        onRename = { if (!isSmart) onRequestRenamePlaylist(playlist) },
+                        onDelete = { if (!isSmart) onRequestDeletePlaylist(playlist) },
+                        onClick = { onPlaylistSelected(playlist) }
+                    )
+                }
             }
         }
-    }
-
-    Spacer(modifier = Modifier.height(8.dp))
-
-    Surface(
-        color = MaterialTheme.colorScheme.surfaceVariant,
-        modifier = Modifier.fillMaxWidth()
-    ) {
-        Column(modifier = Modifier.padding(12.dp)) {
-            if (selectedPlaylist == null) {
-                Text("Select a playlist to view songs")
-                return@Column
-            }
-
-            TextButton(
+    } else {
+        Surface(
+            color = MaterialTheme.colorScheme.surfaceVariant,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Column(modifier = Modifier.padding(12.dp)) {
+                TextButton(
                 onClick = {
                     if (hasUnsavedChanges) {
                         pendingSelectPlaylist = null
@@ -1966,6 +1947,7 @@ private fun PlaylistsSection(
                     }
                 }
             }
+        }
         }
     }
 


### PR DESCRIPTION
## Summary
- Replace stacked two-surface playlist layout with mutually exclusive list/detail views
- Selecting a playlist shows detail view at full height instead of splitting the screen
- Back button returns to the full playlist list
- Preserves all editing features (drag reorder, search, dedupe, discard-changes dialog)

## Test plan
- [ ] Open Playlists tab, verify full-height playlist list
- [ ] Tap a playlist, verify full-height detail view with back button
- [ ] Tap Back, verify return to full playlist list
- [ ] Edit a playlist, verify drag reorder and search work
- [ ] Make unsaved edits, tap Back, verify discard-changes dialog appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)