### PR TITLE
Merge Decades tab into Songs as dropdown filter

### DIFF
--- a/mobile/src/main/java/com/example/mymediaplayer/MainActivity.kt
+++ b/mobile/src/main/java/com/example/mymediaplayer/MainActivity.kt
@@ -294,7 +294,6 @@ class MainActivity : ComponentActivity() {
                     onAlbumSortModeChanged = { viewModel.setAlbumSortMode(it) },
                     onGenreSelected = { viewModel.selectGenre(it) },
                     onArtistSelected = { viewModel.selectArtist(it) },
-                    onDecadeSelected = { viewModel.selectDecade(it) },
                     onSearchQueryChanged = { viewModel.updateSearchQuery(it) },
                     onClearSearch = { viewModel.clearSearch() },
                     onClearCategorySelection = { viewModel.clearCategorySelection() },
@@ -707,7 +706,6 @@ class MainActivity : ComponentActivity() {
                 lib.selectedGenre != null -> "genre:${android.net.Uri.encode(lib.selectedGenre)}"
                 lib.selectedAlbum != null -> "album:${android.net.Uri.encode(lib.selectedAlbum)}"
                 lib.selectedArtist != null -> "artist:${android.net.Uri.encode(lib.selectedArtist)}"
-                lib.selectedDecade != null -> "decade:${android.net.Uri.encode(lib.selectedDecade)}"
                 else -> "songs"
             }
             controller.transportControls.playFromMediaId(prefix + browseId, null)
@@ -728,7 +726,6 @@ class MainActivity : ComponentActivity() {
             LibraryTab.Albums -> lib.selectedAlbum ?: "Albums"
             LibraryTab.Genres -> lib.selectedGenre ?: "Genres"
             LibraryTab.Artists -> lib.selectedArtist ?: "Artists"
-            LibraryTab.Decades -> lib.selectedDecade ?: "Decades"
             else -> "All Songs"
         }
     }

--- a/mobile/src/main/java/com/example/mymediaplayer/MainScreen.kt
+++ b/mobile/src/main/java/com/example/mymediaplayer/MainScreen.kt
@@ -1681,11 +1681,6 @@ private fun buildGenreCounts(files: List<MediaFileInfo>): Map<String, Int> =
         bucketGenre(file.genre)
     }.eachCount()
 
-private fun buildDecadeCounts(files: List<MediaFileInfo>): Map<String, Int> =
-    files.groupingBy { file ->
-        decadeLabelForYear(file.year)
-    }.eachCount()
-
 private fun decadeLabelForYear(year: Int?): String {
     if (year == null || year <= 0) return "Unknown Decade"
     val decade = (year / 10) * 10

--- a/mobile/src/main/java/com/example/mymediaplayer/MainScreen.kt
+++ b/mobile/src/main/java/com/example/mymediaplayer/MainScreen.kt
@@ -111,7 +111,6 @@ fun MainScreen(
     onAlbumSortModeChanged: (AlbumSortMode) -> Unit,
     onGenreSelected: (String) -> Unit,
     onArtistSelected: (String) -> Unit,
-    onDecadeSelected: (String) -> Unit,
     onSearchQueryChanged: (String) -> Unit,
     onClearCategorySelection: () -> Unit,
     onClearSearch: () -> Unit,
@@ -509,8 +508,6 @@ fun MainScreen(
             val albumCounts = remember(uiState.scan.scannedFiles) { buildAlbumCounts(uiState.scan.scannedFiles) }
             val artistCounts = remember(uiState.scan.scannedFiles) { buildArtistCounts(uiState.scan.scannedFiles) }
             val genreCounts = remember(uiState.scan.scannedFiles) { buildGenreCounts(uiState.scan.scannedFiles) }
-            val decadeCounts = remember(uiState.scan.scannedFiles) { buildDecadeCounts(uiState.scan.scannedFiles) }
-
             val tabs = LibraryTab.values().toList()
             ScrollableTabRow(
                 selectedTabIndex = tabs.indexOf(uiState.library.selectedTab),
@@ -539,9 +536,20 @@ fun MainScreen(
 
             when (uiState.library.selectedTab) {
                 LibraryTab.Songs -> {
+                    var selectedDecade by rememberSaveable { mutableStateOf<String?>(null) }
+                    val availableDecades = remember(uiState.scan.scannedFiles) {
+                        uiState.scan.scannedFiles
+                            .map { decadeLabelForYear(it.year) }
+                            .filter { it != "Unknown Decade" }
+                            .distinct()
+                            .sorted()
+                    }
                     SongsTabContent(
                         songsFavoritesOnly = songsFavoritesOnly,
                         onToggleSongsFavoritesOnly = { songsFavoritesOnly = !songsFavoritesOnly },
+                        selectedDecade = selectedDecade,
+                        availableDecades = availableDecades,
+                        onDecadeSelected = { selectedDecade = it },
                         scannedFiles = uiState.scan.scannedFiles,
                         favoriteUris = uiState.favoriteUris,
                         isPlayingPlaylist = uiState.playback.isPlayingPlaylist,
@@ -717,35 +725,6 @@ fun MainScreen(
                         onCategorySelected = onArtistSelected,
                         onClearCategorySelection = onClearCategorySelection,
                         enableAlphaIndex = true,
-                        songs = uiState.library.filteredSongs,
-                        isPlaying = false,
-                        isPlayingPlaylist = uiState.playback.isPlayingPlaylist,
-                        hasNext = uiState.playback.hasNext,
-                        hasPrev = uiState.playback.hasPrev,
-                        onPlay = { onPlaySongs(uiState.library.filteredSongs) },
-                        onShuffle = { onShuffleSongs(uiState.library.filteredSongs) },
-                        onStop = onStop,
-                        onNext = onNext,
-                        onPrev = onPrev,
-                        onFileClick = onFileClick,
-                        onAddToPlaylist = {
-                            pendingAddFiles = listOf(it)
-                            showAddToPlaylistDialog = true
-                        },
-                        favoriteUris = uiState.favoriteUris,
-                        onToggleFavorite = onToggleFavorite,
-                        currentMediaId = uiState.playback.currentMediaId
-                    )
-                }
-                LibraryTab.Decades -> {
-                    CategoryTabContent(
-                        title = "Decades",
-                        categories = uiState.library.decades,
-                        categoryCounts = decadeCounts,
-                        isLoading = uiState.library.isMetadataLoading,
-                        selectedLabel = uiState.library.selectedDecade,
-                        onCategorySelected = onDecadeSelected,
-                        onClearCategorySelection = onClearCategorySelection,
                         songs = uiState.library.filteredSongs,
                         isPlaying = false,
                         isPlayingPlaylist = uiState.playback.isPlayingPlaylist,
@@ -2784,6 +2763,9 @@ private fun formatDuration(durationMs: Long): String {
 private fun SongsTabContent(
     songsFavoritesOnly: Boolean,
     onToggleSongsFavoritesOnly: () -> Unit,
+    selectedDecade: String?,
+    availableDecades: List<String>,
+    onDecadeSelected: (String?) -> Unit,
     scannedFiles: List<MediaFileInfo>,
     favoriteUris: Set<String>,
     isPlayingPlaylist: Boolean,
@@ -2799,17 +2781,49 @@ private fun SongsTabContent(
     onToggleFavorite: (MediaFileInfo) -> Unit,
     currentMediaId: String?
 ) {
-    val songsForTab = if (songsFavoritesOnly) {
-        scannedFiles.filter { it.uriString in favoriteUris }
+    val filteredByDecade = if (selectedDecade != null) {
+        scannedFiles.filter { decadeLabelForYear(it.year) == selectedDecade }
     } else {
         scannedFiles
     }
+    val songsForTab = if (songsFavoritesOnly) {
+        filteredByDecade.filter { it.uriString in favoriteUris }
+    } else {
+        filteredByDecade
+    }
+
     Row(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.spacedBy(8.dp)
     ) {
         TextButton(onClick = onToggleSongsFavoritesOnly) {
             Text(if (songsFavoritesOnly) "Show all songs" else "Favorites only")
+        }
+
+        var decadeMenuExpanded by remember { mutableStateOf(false) }
+        TextButton(onClick = { decadeMenuExpanded = true }) {
+            Text("Decade: ${selectedDecade ?: "All"}")
+        }
+        DropdownMenu(
+            expanded = decadeMenuExpanded,
+            onDismissRequest = { decadeMenuExpanded = false }
+        ) {
+            DropdownMenuItem(
+                text = { Text("All") },
+                onClick = {
+                    decadeMenuExpanded = false
+                    onDecadeSelected(null)
+                }
+            )
+            availableDecades.forEach { decade ->
+                DropdownMenuItem(
+                    text = { Text(decade) },
+                    onClick = {
+                        decadeMenuExpanded = false
+                        onDecadeSelected(decade)
+                    }
+                )
+            }
         }
     }
     Spacer(modifier = Modifier.height(4.dp))

--- a/mobile/src/main/java/com/example/mymediaplayer/MainViewModel.kt
+++ b/mobile/src/main/java/com/example/mymediaplayer/MainViewModel.kt
@@ -64,12 +64,10 @@ data class LibraryState(
     val selectedAlbum: String? = null,
     val selectedGenre: String? = null,
     val selectedArtist: String? = null,
-    val selectedDecade: String? = null,
     val filteredSongs: List<MediaFileInfo> = emptyList(),
     val albums: List<String> = emptyList(),
     val genres: List<String> = emptyList(),
     val artists: List<String> = emptyList(),
-    val decades: List<String> = emptyList(),
     val isMetadataLoading: Boolean = false
 )
 
@@ -103,8 +101,7 @@ enum class LibraryTab(val label: String) {
     Playlists("Playlists"),
     Albums("Albums"),
     Genres("Genres"),
-    Artists("Artists"),
-    Decades("Decades")
+    Artists("Artists")
 }
 
 enum class AlbumSortMode(val label: String) {
@@ -461,12 +458,10 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                 selectedAlbum = if (tab == LibraryTab.Albums) lib.selectedAlbum else null,
                 selectedGenre = if (tab == LibraryTab.Genres) lib.selectedGenre else null,
                 selectedArtist = if (tab == LibraryTab.Artists) lib.selectedArtist else null,
-                selectedDecade = if (tab == LibraryTab.Decades) lib.selectedDecade else null,
                 filteredSongs = if (
                     tab == LibraryTab.Albums ||
                     tab == LibraryTab.Genres ||
-                    tab == LibraryTab.Artists ||
-                    tab == LibraryTab.Decades
+                    tab == LibraryTab.Artists
                 ) {
                     lib.filteredSongs
                 } else {
@@ -477,8 +472,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         if (
             tab == LibraryTab.Albums ||
             tab == LibraryTab.Genres ||
-            tab == LibraryTab.Artists ||
-            tab == LibraryTab.Decades
+            tab == LibraryTab.Artists
         ) {
             ensureMetadataLoaded()
         }
@@ -514,21 +508,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             library = current.library.copy(
                 selectedAlbum = null,
                 selectedGenre = null,
-                selectedArtist = artist,
-                selectedDecade = null
-            )
-        )
-        applyFilteredSongs()
-    }
-
-    fun selectDecade(decade: String) {
-        val current = _uiState.value
-        _uiState.value = current.copy(
-            library = current.library.copy(
-                selectedAlbum = null,
-                selectedGenre = null,
-                selectedArtist = null,
-                selectedDecade = decade
+                selectedArtist = artist
             )
         )
         applyFilteredSongs()
@@ -557,7 +537,6 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                 selectedAlbum = null,
                 selectedGenre = null,
                 selectedArtist = null,
-                selectedDecade = null,
                 filteredSongs = emptyList()
             )
         )
@@ -1178,7 +1157,6 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             mediaCacheService.buildAlbumArtistIndexesFromCache()
             val artists = mediaCacheService.artists()
             val genres = mediaCacheService.genres()
-            val decades = mediaCacheService.decades()
             metadataKey = sourceKey
             val cur2 = _uiState.value
             _uiState.value = cur2.copy(
@@ -1186,7 +1164,6 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                     albums = sortedAlbumsForMode(cur2.library.albumSortMode),
                     genres = genres,
                     artists = artists,
-                    decades = decades,
                     isMetadataLoading = false
                 )
             )
@@ -1204,8 +1181,6 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                 mediaCacheService.songsForGenre(lib.selectedGenre)
             lib.selectedArtist != null ->
                 mediaCacheService.songsForArtist(lib.selectedArtist)
-            lib.selectedDecade != null ->
-                mediaCacheService.songsForDecade(lib.selectedDecade)
             else -> emptyList()
         }
         _uiState.value = current.copy(


### PR DESCRIPTION
## Summary
- Remove Decades tab, reducing tab count from 6 to 5
- Add decade filter dropdown to Songs tab alongside favorites toggle
- Decade selection managed as local UI state (survives config changes)
- Android Auto browse tree decades are unchanged

## Test plan
- [ ] Verify only 5 tabs show (Songs, Playlists, Albums, Genres, Artists)
- [ ] Open Songs tab, verify "Decade: All" dropdown appears
- [ ] Select a decade, verify song list filters correctly
- [ ] Combine decade filter with favorites filter, verify both work together
- [ ] Verify Android Auto still shows decades in browse tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)