### PR TITLE
Clean up Android Auto category item text formatting

### DIFF
--- a/shared/src/main/java/com/example/mymediaplayer/shared/MediaItemBuilders.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/MediaItemBuilders.kt
@@ -57,10 +57,13 @@ internal fun buildCategoryListItems(
     iconUri: Uri? = null
 ): MutableList<MediaItem> {
     return categories.map { category ->
-        val label = counts?.get(category)?.let { "$category ($it)" } ?: category
         val builder = MediaDescriptionCompat.Builder()
             .setMediaId(prefix + Uri.encode(category))
-            .setTitle(label)
+            .setTitle(category)
+        val count = counts?.get(category)
+        if (count != null) {
+            builder.setSubtitle("$count song${if (count != 1) "s" else ""}")
+        }
         if (iconUri != null) {
             builder.setIconUri(iconUri)
         }

--- a/shared/src/test/java/com/example/mymediaplayer/shared/MediaItemBuildersTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/MediaItemBuildersTest.kt
@@ -113,7 +113,7 @@ class MediaItemBuildersTest {
     }
 
     @Test
-    fun buildCategoryListItems_withCounts_includesCountsInTitle() {
+    fun buildCategoryListItems_withCounts_showsCountAsSubtitle() {
         val categories = listOf("Rock", "Pop")
         val prefix = "category_prefix/"
         val counts = mapOf("Rock" to 10, "Pop" to 5)
@@ -123,14 +123,29 @@ class MediaItemBuildersTest {
         assertEquals(2, result.size)
 
         assertEquals("category_prefix/Rock", result[0].mediaId)
-        assertEquals("Rock (10)", result[0].description.title)
+        assertEquals("Rock", result[0].description.title)
+        assertEquals("10 songs", result[0].description.subtitle)
         assertNull(result[0].description.iconUri)
         assertEquals(MediaItem.FLAG_BROWSABLE, result[0].flags)
 
         assertEquals("category_prefix/Pop", result[1].mediaId)
-        assertEquals("Pop (5)", result[1].description.title)
+        assertEquals("Pop", result[1].description.title)
+        assertEquals("5 songs", result[1].description.subtitle)
         assertNull(result[1].description.iconUri)
         assertEquals(MediaItem.FLAG_BROWSABLE, result[1].flags)
+    }
+
+    @Test
+    fun buildCategoryListItems_withSingularCount_showsSongNotSongs() {
+        val categories = listOf("Jazz")
+        val prefix = "category_prefix/"
+        val counts = mapOf("Jazz" to 1)
+
+        val result = buildCategoryListItems(categories, prefix, counts = counts)
+
+        assertEquals(1, result.size)
+        assertEquals("Jazz", result[0].description.title)
+        assertEquals("1 song", result[0].description.subtitle)
     }
 
     @Test

--- a/shared/src/test/java/com/example/mymediaplayer/shared/MyMusicServiceTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/MyMusicServiceTest.kt
@@ -69,7 +69,7 @@ class MyMusicServiceTest {
     }
 
     @Test
-    fun buildCategoryListItems_appliesCountsToLabels() {
+    fun buildCategoryListItems_appliesCountsAsSubtitle() {
         val categories = listOf("Rock", "Pop")
         val counts = mapOf("Rock" to 2)
 
@@ -77,9 +77,11 @@ class MyMusicServiceTest {
 
         assertEquals(2, items.size)
         assertEquals("genre:Rock", items[0].description.mediaId)
-        assertEquals("Rock (2)", items[0].description.title)
+        assertEquals("Rock", items[0].description.title)
+        assertEquals("2 songs", items[0].description.subtitle)
         assertEquals("genre:Pop", items[1].description.mediaId)
         assertEquals("Pop", items[1].description.title)
+        assertNull(items[1].description.subtitle)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Move song counts from category titles to subtitles in Android Auto browse tree
- Before: title "Rock (10)", no subtitle
- After: title "Rock", subtitle "10 songs" (with proper pluralization)
- Home-level categories unchanged (already used subtitles correctly)

## Test plan
- [ ] Connect to Android Auto (or DHU)
- [ ] Browse into Genres, verify genre names show as titles, counts as subtitles
- [ ] Browse into Albums, verify same pattern
- [ ] Verify singular "1 song" vs plural "10 songs"
- [ ] Verify home-level categories still show correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)