### PR TITLE
🔒 Fix insecure temporary file creation

### DIFF
--- a/shared/src/main/java/com/example/mymediaplayer/shared/AnnouncementPreGenerator.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/AnnouncementPreGenerator.kt
@@ -17,6 +17,7 @@ import java.io.File
 import java.io.OutputStreamWriter
 import java.net.HttpURLConnection
 import java.net.URL
+import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -303,7 +304,8 @@ internal class AnnouncementPreGenerator(
                     .getString("audioContent")
                 val audioBytes = Base64.decode(audioBase64, Base64.DEFAULT)
 
-                val file = File.createTempFile("announcement_", ".mp3", context.cacheDir)
+                val fileName = "announcement_${UUID.randomUUID()}.mp3"
+                val file = File(context.cacheDir, fileName)
                 file.writeBytes(audioBytes)
                 Log.d(TAG, "Saved pre-generated announcement to ${file.name} (${audioBytes.size} bytes)")
                 file

--- a/shared/src/main/java/com/example/mymediaplayer/shared/AnnouncementPreGenerator.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/AnnouncementPreGenerator.kt
@@ -17,7 +17,6 @@ import java.io.File
 import java.io.OutputStreamWriter
 import java.net.HttpURLConnection
 import java.net.URL
-import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -304,8 +303,13 @@ internal class AnnouncementPreGenerator(
                     .getString("audioContent")
                 val audioBytes = Base64.decode(audioBase64, Base64.DEFAULT)
 
-                val fileName = "announcement_${UUID.randomUUID()}.mp3"
-                val file = File(context.cacheDir, fileName)
+                val file = File.createTempFile("announcement_", ".mp3", context.cacheDir).apply {
+                    setReadable(false, false)
+                    setWritable(false, false)
+                    setExecutable(false, false)
+                    setReadable(true, true)
+                    setWritable(true, true)
+                }
                 file.writeBytes(audioBytes)
                 Log.d(TAG, "Saved pre-generated announcement to ${file.name} (${audioBytes.size} bytes)")
                 file

--- a/shared/src/main/java/com/example/mymediaplayer/shared/AnnouncementPreGenerator.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/AnnouncementPreGenerator.kt
@@ -303,13 +303,10 @@ internal class AnnouncementPreGenerator(
                     .getString("audioContent")
                 val audioBytes = Base64.decode(audioBase64, Base64.DEFAULT)
 
-                val file = File.createTempFile("announcement_", ".mp3", context.cacheDir).apply {
-                    setReadable(false, false)
-                    setWritable(false, false)
-                    setExecutable(false, false)
-                    setReadable(true, true)
-                    setWritable(true, true)
-                }
+                val file = File.createTempFile("announcement_", ".mp3", context.cacheDir)
+                file.setReadable(true, true)
+                file.setWritable(true, true)
+                file.setExecutable(false)
                 file.writeBytes(audioBytes)
                 Log.d(TAG, "Saved pre-generated announcement to ${file.name} (${audioBytes.size} bytes)")
                 file

--- a/shared/src/main/java/com/example/mymediaplayer/shared/AnnouncementPreGenerator.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/AnnouncementPreGenerator.kt
@@ -17,6 +17,7 @@ import java.io.File
 import java.io.OutputStreamWriter
 import java.net.HttpURLConnection
 import java.net.URL
+import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -303,10 +304,8 @@ internal class AnnouncementPreGenerator(
                     .getString("audioContent")
                 val audioBytes = Base64.decode(audioBase64, Base64.DEFAULT)
 
-                val file = File.createTempFile("announcement_", ".mp3", context.cacheDir)
-                file.setReadable(true, true)
-                file.setWritable(true, true)
-                file.setExecutable(false)
+                val file = File(context.cacheDir, "${UUID.randomUUID()}.mp3")
+                file.createNewFile()
                 file.writeBytes(audioBytes)
                 Log.d(TAG, "Saved pre-generated announcement to ${file.name} (${audioBytes.size} bytes)")
                 file


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is the use of `File.createTempFile` to create temporary files for the downloaded audio data.
⚠️ **Risk:** The potential impact if left unfixed is that `File.createTempFile` may have insecure permissions and predictable file names in older Java/Android versions, which could lead to race conditions or privilege escalation.
🛡️ **Solution:** The fix replaces `File.createTempFile` with manual file creation using `UUID.randomUUID().toString()` to ensure a unique, unpredictable filename. The file is created directly in `context.cacheDir`.

---
*PR created automatically by Jules for task [14203714593975726896](https://jules.google.com/task/14203714593975726896) started by @kimptoc*