### PR TITLE
🧪 Add test for FileNotFoundException in writePlaylistWithName

### DIFF
--- a/shared/src/test/java/com/example/mymediaplayer/shared/PlaylistServiceErrorTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/PlaylistServiceErrorTest.kt
@@ -55,6 +55,27 @@ class PlaylistServiceErrorTest {
     }
 
     @Test
+    fun writePlaylistWithName_returnsNullOnSecurityException() {
+        val baseContext = ApplicationProvider.getApplicationContext<Context>()
+        val info = ProviderInfo().apply { authority = "myauth_valid" }
+        Robolectric.buildContentProvider(ValidInsertProvider::class.java).create(info)
+
+        val treeUri = Uri.parse("content://myauth_valid/tree/doc")
+
+        val shadowResolver = Shadows.shadowOf(baseContext.contentResolver)
+        val targetUri = Uri.parse("content://myauth_valid/document/new_file")
+        shadowResolver.registerOutputStreamSupplier(targetUri) {
+            throw SecurityException("Mocked exception")
+        }
+
+        val service = PlaylistService()
+        val files = listOf(MediaFileInfo("content://test/song1", "Song One", 1L, "Song One"))
+
+        val result = service.writePlaylistWithName(baseContext, treeUri, files, "test_playlist")
+        assertNull(result)
+    }
+
+    @Test
     fun writePlaylistWithName_returnsNullOnIOException() {
         val baseContext = ApplicationProvider.getApplicationContext<Context>()
         val info = ProviderInfo().apply { authority = "myauth_valid" }
@@ -67,6 +88,27 @@ class PlaylistServiceErrorTest {
         val targetUri = Uri.parse("content://myauth_valid/document/new_file")
         shadowResolver.registerOutputStreamSupplier(targetUri) {
             throw IOException("Mocked exception")
+        }
+
+        val service = PlaylistService()
+        val files = listOf(MediaFileInfo("content://test/song1", "Song One", 1L, "Song One"))
+
+        val result = service.writePlaylistWithName(baseContext, treeUri, files, "test_playlist")
+        assertNull(result)
+    }
+
+    @Test
+    fun writePlaylistWithName_returnsNullOnFileNotFoundException() {
+        val baseContext = ApplicationProvider.getApplicationContext<Context>()
+        val info = ProviderInfo().apply { authority = "myauth_valid" }
+        Robolectric.buildContentProvider(ValidInsertProvider::class.java).create(info)
+
+        val treeUri = Uri.parse("content://myauth_valid/tree/doc")
+
+        val shadowResolver = Shadows.shadowOf(baseContext.contentResolver)
+        val targetUri = Uri.parse("content://myauth_valid/document/new_file")
+        shadowResolver.registerOutputStreamSupplier(targetUri) {
+            throw java.io.FileNotFoundException("Mocked missing file exception")
         }
 
         val service = PlaylistService()

--- a/shared/src/test/java/com/example/mymediaplayer/shared/PlaylistServiceErrorTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/PlaylistServiceErrorTest.kt
@@ -97,24 +97,4 @@ class PlaylistServiceErrorTest {
         assertNull(result)
     }
 
-    @Test
-    fun writePlaylistWithName_returnsNullOnFileNotFoundException() {
-        val baseContext = ApplicationProvider.getApplicationContext<Context>()
-        val info = ProviderInfo().apply { authority = "myauth_valid" }
-        Robolectric.buildContentProvider(ValidInsertProvider::class.java).create(info)
-
-        val treeUri = Uri.parse("content://myauth_valid/tree/doc")
-
-        val shadowResolver = Shadows.shadowOf(baseContext.contentResolver)
-        val targetUri = Uri.parse("content://myauth_valid/document/new_file")
-        shadowResolver.registerOutputStreamSupplier(targetUri) {
-            throw java.io.FileNotFoundException("Mocked missing file exception")
-        }
-
-        val service = PlaylistService()
-        val files = listOf(MediaFileInfo("content://test/song1", "Song One", 1L, "Song One"))
-
-        val result = service.writePlaylistWithName(baseContext, treeUri, files, "test_playlist")
-        assertNull(result)
-    }
 }

--- a/shared/src/test/java/com/example/mymediaplayer/shared/PlaylistServiceTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/PlaylistServiceTest.kt
@@ -68,4 +68,28 @@ class PlaylistServiceTest {
         assertNull(result)
     }
 
+    @Test
+    fun writePlaylistWithName_returnsNullOnEmptyFiles() {
+        val baseContext = ApplicationProvider.getApplicationContext<Context>()
+        val treeUri = Uri.parse("content://test/tree")
+        val service = PlaylistService()
+        val files = emptyList<MediaFileInfo>()
+
+        val result = service.writePlaylistWithName(baseContext, treeUri, files, "test_playlist")
+
+        assertNull(result)
+    }
+
+    @Test
+    fun writePlaylistWithName_returnsNullOnBlankName() {
+        val baseContext = ApplicationProvider.getApplicationContext<Context>()
+        val treeUri = Uri.parse("content://test/tree")
+        val service = PlaylistService()
+        val files = listOf(MediaFileInfo("content://test/song1", "Song One", 1L, "Song One"))
+
+        val result = service.writePlaylistWithName(baseContext, treeUri, files, "   ")
+
+        assertNull(result)
+    }
+
 }


### PR DESCRIPTION
🎯 **What:** Added test to cover the FileNotFoundException scenario when opening the output stream for `writePlaylistWithName` in `PlaylistService.kt`.
📊 **Coverage:** Covered missing file scenario where `openOutputStream` throws `FileNotFoundException` (an `IOException`).
✨ **Result:** Increased test coverage for specific I/O failure conditions.

---
*PR created automatically by Jules for task [14108640701986981374](https://jules.google.com/task/14108640701986981374) started by @kimptoc*