### PR TITLE
Fix compilation errors from incomplete settings/decades merge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,25 @@
+name: Build & Test
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 11
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - name: Build debug APK
+        run: ./gradlew assembleDebug
+
+      - name: Run unit tests
+        run: ./gradlew test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
 
       - uses: gradle/actions/setup-gradle@v4
 

--- a/mobile/src/main/java/com/example/mymediaplayer/MainActivity.kt
+++ b/mobile/src/main/java/com/example/mymediaplayer/MainActivity.kt
@@ -298,100 +298,100 @@ class MainActivity : ComponentActivity() {
                         onBack = { showSettings.value = false }
                     )
                 } else {
-                MainScreen(
-                    uiState = uiState.value,
-                    onSelectFolderWithLimit = { limit, deepScan ->
-                        pendingScanLimit = limit
-                        pendingDeepScan = deepScan
-                        openDocumentTree.launch(null)
-                    },
-                    onChoosePlaylistSaveFolder = {
-                        openPlaylistDocumentTree.launch(null)
-                    },
-                    onScanWholeDriveWithLimit = ::handleScanWholeDriveWithLimit,
-                    onFileClick = { file -> playFile(file, uiState.value.scan.scannedFiles) },
-                    onPlayPause = { togglePlayPause(uiState.value.playback.isPlaying) },
-                    onStop = { stopPlayback() },
-                    onNext = { skipToNext() },
-                    onPrev = { skipToPrevious() },
-                    onToggleRepeat = { toggleRepeatMode(uiState.value.playback.repeatMode) },
-                    onQueueItemSelected = { queueId -> skipToQueueItem(queueId) },
-                    onSeekTo = { positionMs -> seekTo(positionMs) },
-                    onCreatePlaylist = { count -> viewModel.createRandomPlaylist(count) },
-                    onPlaylistMessageDismissed = { viewModel.clearPlaylistMessage() },
-                    onFolderMessageDismissed = { viewModel.clearFolderMessage() },
-                    onScanMessageDismissed = { viewModel.clearScanMessage() },
-                    onTabSelected = { viewModel.selectTab(it) },
-                    onAlbumSelected = { viewModel.selectAlbum(it) },
-                    onAlbumSortModeChanged = { viewModel.setAlbumSortMode(it) },
-                    onGenreSelected = { viewModel.selectGenre(it) },
-                    onArtistSelected = { viewModel.selectArtist(it) },
-                    onSearchQueryChanged = { viewModel.updateSearchQuery(it) },
-                    onClearSearch = { viewModel.clearSearch() },
-                    onClearCategorySelection = { viewModel.clearCategorySelection() },
-                    onPlaylistSelected = { viewModel.selectPlaylist(it) },
-                    onClearPlaylistSelection = { viewModel.clearSelectedPlaylist() },
-                    onDeletePlaylist = { playlist -> viewModel.deletePlaylist(playlist) },
-                    onRenamePlaylist = { playlist, newName ->
-                        viewModel.renamePlaylist(playlist, newName)
-                    },
-                    onSavePlaylistEdits = { playlist, songs ->
-                        viewModel.savePlaylistEdits(playlist, songs)
-                    },
-                    onPlaySongs = { songs ->
-                        playUiList(
-                            songs = songs,
-                            shuffle = false,
-                            queueTitle = queueTitleForCurrentUiList(uiState.value)
-                        )
-                    },
-                    onShuffleSongs = { songs ->
-                        playUiList(
-                            songs = songs,
-                            shuffle = true,
-                            queueTitle = queueTitleForCurrentUiList(uiState.value)
-                        )
-                    },
-                    onPlaySearchResults = { songs ->
-                        playSearchResults(songs, shuffle = false)
-                    },
-                    onShuffleSearchResults = { songs ->
-                        playSearchResults(songs, shuffle = true)
-                    },
-                    onAddToExistingPlaylist = { playlist, files ->
-                        viewModel.addManyToExistingPlaylist(playlist, files)
-                    },
-                    onCreatePlaylistFromSongs = { name, files ->
-                        viewModel.createPlaylistFromSongs(name, files)
-                    },
-                    onToggleFavorite = { file ->
-                        viewModel.toggleFavorite(file.uriString)
-                    },
-                    nowPlayingArt = nowPlayingArt.value,
-                    showPlaylistSaveFolderPrompt = showPlaylistSaveFolderPrompt.value,
-                    onDismissPlaylistSaveFolderPrompt = {
-                        showPlaylistSaveFolderPrompt.value = false
-                    },
-                    onSetPlaylistSaveFolderNow = {
-                        showPlaylistSaveFolderPrompt.value = false
-                        openPlaylistDocumentTree.launch(null)
-                    },
-                    onOpenSettings = { showSettings.value = true },
-                    onPlayPlaylist = { playlist ->
-                        sendFilesToServiceIfNeeded(uiState.value.scan.scannedFiles)
-                        sendPlaylistsToServiceIfNeeded(uiState.value.scan.discoveredPlaylists)
-                        val mediaId = getPlaylistMediaId(playlist.uriString)
-                        mediaController?.transportControls?.playFromMediaId(mediaId, null)
-                    },
-                    onShufflePlaylistSongs = { playlist, songs ->
-                        if (songs.isNotEmpty()) {
+                    MainScreen(
+                        uiState = uiState.value,
+                        onSelectFolderWithLimit = { limit, deepScan ->
+                            pendingScanLimit = limit
+                            pendingDeepScan = deepScan
+                            openDocumentTree.launch(null)
+                        },
+                        onChoosePlaylistSaveFolder = {
+                            openPlaylistDocumentTree.launch(null)
+                        },
+                        onScanWholeDriveWithLimit = ::handleScanWholeDriveWithLimit,
+                        onFileClick = { file -> playFile(file, uiState.value.scan.scannedFiles) },
+                        onPlayPause = { togglePlayPause(uiState.value.playback.isPlaying) },
+                        onStop = { stopPlayback() },
+                        onNext = { skipToNext() },
+                        onPrev = { skipToPrevious() },
+                        onToggleRepeat = { toggleRepeatMode(uiState.value.playback.repeatMode) },
+                        onQueueItemSelected = { queueId -> skipToQueueItem(queueId) },
+                        onSeekTo = { positionMs -> seekTo(positionMs) },
+                        onCreatePlaylist = { count -> viewModel.createRandomPlaylist(count) },
+                        onPlaylistMessageDismissed = { viewModel.clearPlaylistMessage() },
+                        onFolderMessageDismissed = { viewModel.clearFolderMessage() },
+                        onScanMessageDismissed = { viewModel.clearScanMessage() },
+                        onTabSelected = { viewModel.selectTab(it) },
+                        onAlbumSelected = { viewModel.selectAlbum(it) },
+                        onAlbumSortModeChanged = { viewModel.setAlbumSortMode(it) },
+                        onGenreSelected = { viewModel.selectGenre(it) },
+                        onArtistSelected = { viewModel.selectArtist(it) },
+                        onSearchQueryChanged = { viewModel.updateSearchQuery(it) },
+                        onClearSearch = { viewModel.clearSearch() },
+                        onClearCategorySelection = { viewModel.clearCategorySelection() },
+                        onPlaylistSelected = { viewModel.selectPlaylist(it) },
+                        onClearPlaylistSelection = { viewModel.clearSelectedPlaylist() },
+                        onDeletePlaylist = { playlist -> viewModel.deletePlaylist(playlist) },
+                        onRenamePlaylist = { playlist, newName ->
+                            viewModel.renamePlaylist(playlist, newName)
+                        },
+                        onSavePlaylistEdits = { playlist, songs ->
+                            viewModel.savePlaylistEdits(playlist, songs)
+                        },
+                        onPlaySongs = { songs ->
+                            playUiList(
+                                songs = songs,
+                                shuffle = false,
+                                queueTitle = queueTitleForCurrentUiList(uiState.value)
+                            )
+                        },
+                        onShuffleSongs = { songs ->
+                            playUiList(
+                                songs = songs,
+                                shuffle = true,
+                                queueTitle = queueTitleForCurrentUiList(uiState.value)
+                            )
+                        },
+                        onPlaySearchResults = { songs ->
+                            playSearchResults(songs, shuffle = false)
+                        },
+                        onShuffleSearchResults = { songs ->
+                            playSearchResults(songs, shuffle = true)
+                        },
+                        onAddToExistingPlaylist = { playlist, files ->
+                            viewModel.addManyToExistingPlaylist(playlist, files)
+                        },
+                        onCreatePlaylistFromSongs = { name, files ->
+                            viewModel.createPlaylistFromSongs(name, files)
+                        },
+                        onToggleFavorite = { file ->
+                            viewModel.toggleFavorite(file.uriString)
+                        },
+                        nowPlayingArt = nowPlayingArt.value,
+                        showPlaylistSaveFolderPrompt = showPlaylistSaveFolderPrompt.value,
+                        onDismissPlaylistSaveFolderPrompt = {
+                            showPlaylistSaveFolderPrompt.value = false
+                        },
+                        onSetPlaylistSaveFolderNow = {
+                            showPlaylistSaveFolderPrompt.value = false
+                            openPlaylistDocumentTree.launch(null)
+                        },
+                        onOpenSettings = { showSettings.value = true },
+                        onPlayPlaylist = { playlist ->
                             sendFilesToServiceIfNeeded(uiState.value.scan.scannedFiles)
                             sendPlaylistsToServiceIfNeeded(uiState.value.scan.discoveredPlaylists)
-                            val mediaId = getPlaylistShuffleMediaId(playlist.uriString)
+                            val mediaId = getPlaylistMediaId(playlist.uriString)
                             mediaController?.transportControls?.playFromMediaId(mediaId, null)
+                        },
+                        onShufflePlaylistSongs = { playlist, songs ->
+                            if (songs.isNotEmpty()) {
+                                sendFilesToServiceIfNeeded(uiState.value.scan.scannedFiles)
+                                sendPlaylistsToServiceIfNeeded(uiState.value.scan.discoveredPlaylists)
+                                val mediaId = getPlaylistShuffleMediaId(playlist.uriString)
+                                mediaController?.transportControls?.playFromMediaId(mediaId, null)
+                            }
                         }
-                    }
-                )
+                    )
                 }
             }
         }

--- a/mobile/src/main/java/com/example/mymediaplayer/MainActivity.kt
+++ b/mobile/src/main/java/com/example/mymediaplayer/MainActivity.kt
@@ -123,6 +123,7 @@ class MainActivity : ComponentActivity() {
     private val cloudAnnouncementTtsKey = mutableStateOf("")
     private val debugCloudAnnouncements = mutableStateOf(false)
     private val nowPlayingArt = mutableStateOf<Bitmap?>(null)
+    private val showSettings = mutableStateOf(false)
 
     private val bluetoothPermissionLauncher =
         registerForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
@@ -267,6 +268,36 @@ class MainActivity : ComponentActivity() {
         setContent {
             MaterialTheme {
                 val uiState = viewModel.uiState.collectAsState()
+                if (showSettings.value) {
+                    SettingsScreen(
+                        trackVoiceIntroEnabled = trackVoiceIntroEnabled.value,
+                        trackVoiceOutroEnabled = trackVoiceOutroEnabled.value,
+                        onToggleTrackVoiceIntro = { toggleTrackVoiceIntro() },
+                        onToggleTrackVoiceOutro = { toggleTrackVoiceOutro() },
+                        cloudAnnouncementKiloKey = cloudAnnouncementKiloKey.value,
+                        cloudAnnouncementTtsKey = cloudAnnouncementTtsKey.value,
+                        debugCloudAnnouncements = debugCloudAnnouncements.value,
+                        onSetDebugCloudAnnouncements = { enabled ->
+                            debugCloudAnnouncements.value = enabled
+                            getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
+                                .edit()
+                                .putBoolean(KEY_DEBUG_CLOUD_ANNOUNCEMENTS, enabled)
+                                .apply()
+                            sendDebugCloudSettingToService(enabled)
+                        },
+                        onSaveCloudAnnouncementKeys = ::saveCloudAnnouncementKeys,
+                        bluetoothAutoPlayEnabled = bluetoothAutoPlayEnabled.value,
+                        onToggleBluetoothAutoPlay = { toggleBluetoothAutoPlay() },
+                        onAddCurrentBluetoothDevice = { addCurrentBluetoothDeviceToAllowlist() },
+                        trustedBluetoothDevices = trustedBluetoothDevices.value,
+                        bluetoothDiagnostics = bluetoothDiagnostics.value,
+                        onRemoveTrustedBluetoothDevice = { address -> removeTrustedBluetoothDevice(address) },
+                        onClearTrustedBluetoothDevices = { clearTrustedBluetoothDevices() },
+                        onRefreshBluetoothDiagnostics = { refreshBluetoothState() },
+                        onChoosePlaylistSaveFolder = { openPlaylistDocumentTree.launch(null) },
+                        onBack = { showSettings.value = false }
+                    )
+                } else {
                 MainScreen(
                     uiState = uiState.value,
                     onSelectFolderWithLimit = { limit, deepScan ->
@@ -295,7 +326,6 @@ class MainActivity : ComponentActivity() {
                     onAlbumSortModeChanged = { viewModel.setAlbumSortMode(it) },
                     onGenreSelected = { viewModel.selectGenre(it) },
                     onArtistSelected = { viewModel.selectArtist(it) },
-                    onDecadeSelected = { viewModel.selectDecade(it) },
                     onSearchQueryChanged = { viewModel.updateSearchQuery(it) },
                     onClearSearch = { viewModel.clearSearch() },
                     onClearCategorySelection = { viewModel.clearCategorySelection() },
@@ -337,32 +367,6 @@ class MainActivity : ComponentActivity() {
                     onToggleFavorite = { file ->
                         viewModel.toggleFavorite(file.uriString)
                     },
-                    bluetoothAutoPlayEnabled = bluetoothAutoPlayEnabled.value,
-                    trackVoiceIntroEnabled = trackVoiceIntroEnabled.value,
-                    trackVoiceOutroEnabled = trackVoiceOutroEnabled.value,
-                    onToggleBluetoothAutoPlay = {
-                        toggleBluetoothAutoPlay()
-                    },
-                    onToggleTrackVoiceIntro = {
-                        toggleTrackVoiceIntro()
-                    },
-                    onToggleTrackVoiceOutro = {
-                        toggleTrackVoiceOutro()
-                    },
-                    onAddCurrentBluetoothDevice = {
-                        addCurrentBluetoothDeviceToAllowlist()
-                    },
-                    trustedBluetoothDevices = trustedBluetoothDevices.value,
-                    bluetoothDiagnostics = bluetoothDiagnostics.value,
-                    onRemoveTrustedBluetoothDevice = { address ->
-                        removeTrustedBluetoothDevice(address)
-                    },
-                    onClearTrustedBluetoothDevices = {
-                        clearTrustedBluetoothDevices()
-                    },
-                    onRefreshBluetoothDiagnostics = {
-                        refreshBluetoothState()
-                    },
                     nowPlayingArt = nowPlayingArt.value,
                     showPlaylistSaveFolderPrompt = showPlaylistSaveFolderPrompt.value,
                     onDismissPlaylistSaveFolderPrompt = {
@@ -372,18 +376,7 @@ class MainActivity : ComponentActivity() {
                         showPlaylistSaveFolderPrompt.value = false
                         openPlaylistDocumentTree.launch(null)
                     },
-                    cloudAnnouncementKiloKey = cloudAnnouncementKiloKey.value,
-                    cloudAnnouncementTtsKey = cloudAnnouncementTtsKey.value,
-                    onSaveCloudAnnouncementKeys = ::saveCloudAnnouncementKeys,
-                    debugCloudAnnouncements = debugCloudAnnouncements.value,
-                    onSetDebugCloudAnnouncements = { enabled ->
-                        debugCloudAnnouncements.value = enabled
-                        getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
-                            .edit()
-                            .putBoolean(KEY_DEBUG_CLOUD_ANNOUNCEMENTS, enabled)
-                            .apply()
-                        sendDebugCloudSettingToService(enabled)
-                    },
+                    onOpenSettings = { showSettings.value = true },
                     onPlayPlaylist = { playlist ->
                         sendFilesToServiceIfNeeded(uiState.value.scan.scannedFiles)
                         sendPlaylistsToServiceIfNeeded(uiState.value.scan.discoveredPlaylists)
@@ -399,6 +392,7 @@ class MainActivity : ComponentActivity() {
                         }
                     }
                 )
+                }
             }
         }
     }
@@ -708,7 +702,6 @@ class MainActivity : ComponentActivity() {
                 lib.selectedGenre != null -> "genre:${android.net.Uri.encode(lib.selectedGenre)}"
                 lib.selectedAlbum != null -> "album:${android.net.Uri.encode(lib.selectedAlbum)}"
                 lib.selectedArtist != null -> "artist:${android.net.Uri.encode(lib.selectedArtist)}"
-                lib.selectedDecade != null -> "decade:${android.net.Uri.encode(lib.selectedDecade)}"
                 else -> "songs"
             }
             controller.transportControls.playFromMediaId(prefix + browseId, null)
@@ -729,7 +722,6 @@ class MainActivity : ComponentActivity() {
             LibraryTab.Albums -> lib.selectedAlbum ?: "Albums"
             LibraryTab.Genres -> lib.selectedGenre ?: "Genres"
             LibraryTab.Artists -> lib.selectedArtist ?: "Artists"
-            LibraryTab.Decades -> lib.selectedDecade ?: "Decades"
             else -> "All Songs"
         }
     }


### PR DESCRIPTION
## Summary
- Removed settings-related parameters (bluetooth, cloud announcements, debug flags) from the `MainScreen` call — these now live in the separate `SettingsScreen` composable
- Wired up `onOpenSettings` callback to toggle between `MainScreen` and `SettingsScreen`
- Removed references to non-existent `LibraryTab.Decades` and `LibraryState.selectedDecade` (decade filtering is handled locally within `MainScreen`)

## Test plan
- [x] `./gradlew assembleDebug` — builds successfully
- [x] `./gradlew test` — all unit tests pass
- [ ] Manual: verify Settings menu item opens the settings screen
- [ ] Manual: verify back from settings returns to main screen
- [ ] Manual: verify bluetooth/cloud announcement settings still work from settings screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)