### PR TITLE
Fix playlists not showing in Android Auto on resume (#129)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,16 @@
 name: Build & Test
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
+
+permissions:
+  contents: read
+  issues: read
+  checks: write
+  pull-requests: write
 
 jobs:
   build:
@@ -23,3 +31,9 @@ jobs:
 
       - name: Run unit tests
         run: ./gradlew test
+
+      - name: Publish test results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          files: '**/build/test-results/*/TEST-*.xml'

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![Build & Test](https://github.com/kimptoc/MyMediaPlayer/actions/workflows/build.yml/badge.svg)
+
 Basic media player for use with android auto
 
 DEV NOTES

--- a/docs/superpowers/plans/2026-04-05-playlist-resume-fix.md
+++ b/docs/superpowers/plans/2026-04-05-playlist-resume-fix.md
@@ -1,0 +1,201 @@
+# Playlist Resume Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix playlists not showing in Android Auto when resuming after DHU reconnect (issue #129).
+
+**Architecture:** Two bugs combine to cause empty playlists: (1) `ACTION_SET_PLAYLISTS` handler doesn't persist playlists to Room DB, so they're lost on restart, and (2) the phone's dedup logic prevents re-sending playlists after service recreate. Fix both: persist on receipt, and clear dedup state on MediaBrowser reconnection.
+
+**Tech Stack:** Kotlin, Android MediaBrowserServiceCompat, Room DB
+
+---
+
+### Task 1: Persist playlists to Room DB on receipt
+
+When `ACTION_SET_PLAYLISTS` is handled in `MyMusicService`, playlists are added to `mediaCacheService` in memory but never persisted. This means on service restart, the Room DB has no playlists.
+
+**Files:**
+- Modify: `shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt:480-497`
+
+- [ ] **Step 1: Add persistCache call after playlist receipt**
+
+In `MyMusicService.kt`, in the `ACTION_SET_PLAYLISTS` handler (line 480-497), add a `persistCache` call after the playlists are added — same pattern as the `ACTION_SET_MEDIA_FILES` handler at line 437-443.
+
+Find this block:
+
+```kotlin
+                ACTION_SET_PLAYLISTS -> {
+                    if (extras == null) return
+                    val playlistUris = extras.getStringArrayList(EXTRA_PLAYLIST_URIS) ?: return
+                    val playlistNames = extras.getStringArrayList(EXTRA_PLAYLIST_NAMES) ?: return
+
+                    mediaCacheService.clearPlaylists()
+                    val count = minOf(playlistUris.size, playlistNames.size)
+                    for (i in 0 until count) {
+                        mediaCacheService.addPlaylist(
+                            PlaylistInfo(
+                                uriString = playlistUris[i],
+                                displayName = playlistNames[i]
+                            )
+                        )
+                    }
+                    notifyChildrenChanged(ROOT_ID)
+                    notifyChildrenChanged(PLAYLISTS_ID)
+                }
+```
+
+Replace with:
+
+```kotlin
+                ACTION_SET_PLAYLISTS -> {
+                    if (extras == null) return
+                    val playlistUris = extras.getStringArrayList(EXTRA_PLAYLIST_URIS) ?: return
+                    val playlistNames = extras.getStringArrayList(EXTRA_PLAYLIST_NAMES) ?: return
+
+                    mediaCacheService.clearPlaylists()
+                    val count = minOf(playlistUris.size, playlistNames.size)
+                    for (i in 0 until count) {
+                        mediaCacheService.addPlaylist(
+                            PlaylistInfo(
+                                uriString = playlistUris[i],
+                                displayName = playlistNames[i]
+                            )
+                        )
+                    }
+                    serviceScope.launch {
+                        val prefs = getPrefs(this@MyMusicService)
+                        val treeUriStr = prefs.getString(KEY_TREE_URI, null)
+                        if (treeUriStr != null) {
+                            val limit = prefs.getInt(KEY_SCAN_LIMIT, MediaCacheService.MAX_CACHE_SIZE)
+                            mediaCacheService.persistCache(this@MyMusicService, Uri.parse(treeUriStr), limit)
+                        }
+                    }
+                    notifyChildrenChanged(ROOT_ID)
+                    notifyChildrenChanged(PLAYLISTS_ID)
+                }
+```
+
+- [ ] **Step 2: Build and verify no compile errors**
+
+Run: `./gradlew assembleDebug`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 3: Run existing tests to verify no regressions**
+
+Run: `./gradlew test`
+Expected: All tests pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
+git commit -m "fix: persist playlists to Room DB when received from phone
+
+ACTION_SET_PLAYLISTS handler now calls persistCache so playlists
+survive service restart. Fixes part of #129."
+```
+
+---
+
+### Task 2: Clear dedup state on MediaBrowser reconnection
+
+When the service is destroyed and recreated (e.g., DHU reconnect), `connectionCallback.onConnected()` fires in `MainActivity`. At this point, `lastSentPlaylistUris` still holds the old values, preventing re-send. Clear all dedup state in `onConnected` so the next `StateFlow` emission triggers a fresh sync.
+
+**Files:**
+- Modify: `mobile/src/main/java/com/example/mymediaplayer/MainActivity.kt:168-185`
+
+- [ ] **Step 1: Clear dedup state in onConnected**
+
+In `MainActivity.kt`, in the `connectionCallback`'s `onConnected()` method (line 168-185), clear the dedup variables so playlists and files get re-sent to the potentially-new service instance.
+
+Find this block:
+
+```kotlin
+    private val connectionCallback = object : MediaBrowserCompat.ConnectionCallback() {
+        override fun onConnected() {
+            val browser = mediaBrowser ?: return
+            val controller = MediaControllerCompat(this@MainActivity, browser.sessionToken)
+            mediaController = controller
+            MediaControllerCompat.setMediaController(this@MainActivity, controller)
+            controller.registerCallback(controllerCallback)
+            lastPlaybackState = controller.playbackState
+            lastMetadata = controller.metadata
+            lastRepeatMode = controller.repeatMode
+            pushPlaybackState()
+            pushQueueState()
+            viewModel.updateRepeatMode(lastRepeatMode)
+            sendTrackVoiceIntroSettingToService()
+            sendTrackVoiceOutroSettingToService()
+            dispatchPendingVoiceSearchIfNeeded()
+        }
+    }
+```
+
+Replace with:
+
+```kotlin
+    private val connectionCallback = object : MediaBrowserCompat.ConnectionCallback() {
+        override fun onConnected() {
+            val browser = mediaBrowser ?: return
+            val controller = MediaControllerCompat(this@MainActivity, browser.sessionToken)
+            mediaController = controller
+            MediaControllerCompat.setMediaController(this@MainActivity, controller)
+            controller.registerCallback(controllerCallback)
+            lastPlaybackState = controller.playbackState
+            lastMetadata = controller.metadata
+            lastRepeatMode = controller.repeatMode
+            pushPlaybackState()
+            pushQueueState()
+            viewModel.updateRepeatMode(lastRepeatMode)
+            sendTrackVoiceIntroSettingToService()
+            sendTrackVoiceOutroSettingToService()
+            dispatchPendingVoiceSearchIfNeeded()
+
+            // Clear dedup state so playlists and files are re-sent to the
+            // (possibly recreated) service instance.
+            lastSentPlaylistUris = null
+            lastSentUris = null
+            lastSentLargeLibraryCount = null
+        }
+    }
+```
+
+- [ ] **Step 2: Build and verify no compile errors**
+
+Run: `./gradlew assembleDebug`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 3: Run existing tests to verify no regressions**
+
+Run: `./gradlew test`
+Expected: All tests pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mobile/src/main/java/com/example/mymediaplayer/MainActivity.kt
+git commit -m "fix: clear dedup state on MediaBrowser reconnect
+
+Clears lastSentPlaylistUris, lastSentUris, and lastSentLargeLibraryCount
+in onConnected so playlists and files are re-sent after service recreate.
+Fixes #129."
+```
+
+---
+
+### Task 3: Manual verification
+
+- [ ] **Step 1: Connect phone via USB and start DHU**
+
+```bash
+cd $HOME/Library/Android/sdk/extras/google/auto
+./desktop-head-unit --usb
+```
+
+- [ ] **Step 2: Verify playlists appear in Android Auto**
+
+Navigate to the media app in the DHU. Confirm playlists are listed.
+
+- [ ] **Step 3: Simulate service recreate**
+
+Disconnect and reconnect the DHU (or kill the app process from Android Studio and let it restart). Verify playlists still appear after reconnection.

--- a/docs/superpowers/specs/2026-04-05-playlist-resume-fix-design.md
+++ b/docs/superpowers/specs/2026-04-05-playlist-resume-fix-design.md
@@ -1,0 +1,87 @@
+# Playlist Resume Fix — Design Spec
+
+**Issue:** [#129](https://github.com/kimptoc/MyMediaPlayer/issues/129) — Playlists don't show in Android Auto when resuming, despite being visible on phone.
+
+## Root Cause
+
+Two bugs combine to cause empty playlists on service restart:
+
+### Bug 1: Playlists never persisted to Room DB
+
+When the phone sends playlists via `ACTION_SET_PLAYLISTS` (`MyMusicService.kt:480`), the handler adds them to `mediaCacheService` in memory and calls `notifyChildrenChanged`, but **does not call `persistCache`**. Compare with `ACTION_SET_MEDIA_FILES` (`MyMusicService.kt:437`) which does persist.
+
+Result: On service restart, `loadPersistedCache` loads from Room DB, but the playlists table is empty (or stale from a prior scan that happened to persist before playlists arrived).
+
+### Bug 2: Phone dedup prevents re-sending playlists
+
+`MainActivity.sendPlaylistsToServiceIfNeeded` (`MainActivity.kt:658`) compares current playlist URIs against `lastSentPlaylistUris` and returns early if they match. After a service destroy/recreate, the service has lost its in-memory playlists, but the phone still holds the old `lastSentPlaylistUris` — so it never re-sends.
+
+## Fix
+
+### Fix 1: Persist playlists on receipt
+
+In `MyMusicService`, after `ACTION_SET_PLAYLISTS` adds playlists to `mediaCacheService`, call `persistCache` in a coroutine (same pattern as `ACTION_SET_MEDIA_FILES`).
+
+**File:** `MyMusicService.kt`, inside the `ACTION_SET_PLAYLISTS` handler (~line 494)
+
+```kotlin
+// After adding playlists, persist to Room DB
+serviceScope.launch {
+    val prefs = getPrefs(this@MyMusicService)
+    val treeUriStr = prefs.getString(KEY_TREE_URI, null)
+    if (treeUriStr != null) {
+        val limit = prefs.getInt(KEY_SCAN_LIMIT, MediaCacheService.MAX_CACHE_SIZE)
+        mediaCacheService.persistCache(this@MyMusicService, Uri.parse(treeUriStr), limit)
+    }
+}
+```
+
+### Fix 2: Broadcast intent to reset phone's dedup state
+
+**New constant:** `ACTION_REQUEST_PLAYLIST_SYNC` in `MyMusicService` companion object.
+
+**Service side (MyMusicService.kt):** At the end of `onCreate`, after `loadCachedTreeIfAvailable()`, send a local broadcast:
+
+```kotlin
+LocalBroadcastManager.getInstance(this)
+    .sendBroadcast(Intent(ACTION_REQUEST_PLAYLIST_SYNC))
+```
+
+**Phone side (MainActivity.kt):** Register a `BroadcastReceiver` in `onCreate`/`onDestroy` that clears `lastSentPlaylistUris` on receipt, triggering the next `StateFlow` emission to re-send:
+
+```kotlin
+private val playlistSyncReceiver = object : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        lastSentPlaylistUris = null
+    }
+}
+```
+
+Register in `onCreate`:
+```kotlin
+LocalBroadcastManager.getInstance(this)
+    .registerReceiver(playlistSyncReceiver, IntentFilter(ACTION_REQUEST_PLAYLIST_SYNC))
+```
+
+Unregister in `onDestroy`:
+```kotlin
+LocalBroadcastManager.getInstance(this)
+    .unregisterReceiver(playlistSyncReceiver)
+```
+
+## Why LocalBroadcastManager
+
+Since the service runs in the same process as the activity, `LocalBroadcastManager` is appropriate — no need for system-wide broadcasts. It's simpler and more efficient.
+
+**Note:** `LocalBroadcastManager` is deprecated in favor of other in-process patterns (LiveData, Flow, etc.). However, since the service and activity already communicate via custom actions on `MediaBrowserServiceCompat`, and the receiver pattern is minimal (one receiver, one intent), this is pragmatic and consistent with the existing architecture. If preferred, an alternative is to use a `SharedFlow` on a shared singleton, but that adds more structural change.
+
+## Testing
+
+- Existing unit tests should continue to pass (no behavior change for normal flow).
+- Manual test: connect DHU, verify playlists show, disconnect/reconnect DHU, verify playlists still show.
+- Consider adding a unit test that verifies `persistCache` is called after `ACTION_SET_PLAYLISTS`.
+
+## Files Modified
+
+1. `shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt` — persist on playlist receipt + broadcast sync request
+2. `mobile/src/main/java/com/example/mymediaplayer/MainActivity.kt` — register receiver to clear dedup state

--- a/mobile/src/main/java/com/example/mymediaplayer/MainActivity.kt
+++ b/mobile/src/main/java/com/example/mymediaplayer/MainActivity.kt
@@ -181,6 +181,20 @@ class MainActivity : ComponentActivity() {
             sendTrackVoiceIntroSettingToService()
             sendTrackVoiceOutroSettingToService()
             dispatchPendingVoiceSearchIfNeeded()
+
+            // Clear dedup state and re-send data to the (possibly recreated)
+            // service instance. Clearing alone isn't enough because StateFlow
+            // won't re-emit if the value hasn't changed.
+            lastSentUris = null
+            lastSentLargeLibraryCount = null
+            lastSentPlaylistUris = null
+            val scanState = viewModel.uiState.value.scan
+            if (scanState.scannedFiles.isNotEmpty()) {
+                sendFilesToServiceIfNeeded(scanState.scannedFiles)
+            }
+            if (scanState.discoveredPlaylists.isNotEmpty()) {
+                sendPlaylistsToServiceIfNeeded(scanState.discoveredPlaylists)
+            }
         }
     }
 

--- a/shared/src/main/java/com/example/mymediaplayer/shared/MediaCacheDatabase.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/MediaCacheDatabase.kt
@@ -84,6 +84,12 @@ interface MediaCacheDao {
         if (playlists.isNotEmpty()) insertPlaylists(playlists)
         upsertScanState(state)
     }
+
+    @Transaction
+    fun replacePlaylists(playlists: List<PlaylistEntity>) {
+        clearPlaylists()
+        if (playlists.isNotEmpty()) insertPlaylists(playlists)
+    }
 }
 
 @Database(

--- a/shared/src/main/java/com/example/mymediaplayer/shared/MediaCacheService.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/MediaCacheService.kt
@@ -458,6 +458,15 @@ class MediaCacheService {
         return PersistedCache(files, playlists, state.scannedAt)
     }
 
+    fun persistPlaylists(context: Context) {
+        val db = MediaCacheDatabase.getInstance(context)
+        val dao = db.cacheDao()
+        val playlists = synchronized(cacheLock) { _discoveredPlaylists.toList() }.map {
+            PlaylistEntity(uriString = it.uriString, displayName = it.displayName)
+        }
+        dao.replacePlaylists(playlists)
+    }
+
     fun persistCache(context: Context, treeUri: Uri, maxFiles: Int) {
         val db = MediaCacheDatabase.getInstance(context)
         val dao = db.cacheDao()

--- a/shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
@@ -492,6 +492,9 @@ class MyMusicService : MediaBrowserServiceCompat() {
                             )
                         )
                     }
+                    serviceScope.launch {
+                        mediaCacheService.persistPlaylists(this@MyMusicService)
+                    }
                     notifyChildrenChanged(ROOT_ID)
                     notifyChildrenChanged(PLAYLISTS_ID)
                 }


### PR DESCRIPTION
## Summary

- **Persist playlists to Room DB** on receipt via `ACTION_SET_PLAYLISTS` — previously playlists were only held in memory and lost on service restart. Added a dedicated `persistPlaylists` method that only touches the playlists table (avoiding the full `replaceCache` which would wipe media files if they hadn't been received yet).
- **Clear dedup state and re-send data on MediaBrowser reconnect** — `onConnected()` now resets `lastSentPlaylistUris`/`lastSentUris`/`lastSentLargeLibraryCount` and proactively re-sends files and playlists to the (possibly recreated) service instance.
- Also adds CI test result reporting and build badge (unrelated but included in this branch).

Fixes #129

## Test plan

- [ ] Connect phone via USB, start DHU, verify playlists appear in Android Auto
- [ ] Disconnect and reconnect the DHU (or kill app process), verify playlists still appear after reconnection
- [ ] Verify existing unit tests pass (`./gradlew test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)