### PR TITLE
Clean up playlist ID usage across phone and Auto

### DIFF
--- a/mobile/src/main/java/com/example/mymediaplayer/MainActivity.kt
+++ b/mobile/src/main/java/com/example/mymediaplayer/MainActivity.kt
@@ -33,6 +33,7 @@ import com.example.mymediaplayer.shared.ApiKeyStore
 import com.example.mymediaplayer.shared.MediaCacheService
 import com.example.mymediaplayer.shared.MyMusicService
 import com.example.mymediaplayer.shared.PlaylistInfo
+import com.example.mymediaplayer.shared.playlistShortId
 import kotlinx.coroutines.launch
 import androidx.core.content.ContextCompat
 import androidx.core.app.NotificationManagerCompat
@@ -71,7 +72,7 @@ class MainActivity : ComponentActivity() {
         private const val ACTION_PLAY_UI_LIST = "PLAY_UI_LIST"
         private const val ACTION_SHUFFLE_PREFIX = "action:shuffle:"
         private const val SMART_PLAYLIST_PREFIX = "smart_playlist:"
-        private const val PLAYLIST_URI_PREFIX = "playlist_uri:"
+        private const val PLAYLIST_SHORT_PREFIX = "pl:"
         private const val ACTION_SET_TRACK_VOICE_INTRO = "SET_TRACK_VOICE_INTRO"
         private const val ACTION_SET_TRACK_VOICE_OUTRO = "SET_TRACK_VOICE_OUTRO"
         private const val ACTION_SET_DEBUG_CLOUD = "SET_DEBUG_CLOUD"
@@ -961,7 +962,7 @@ class MainActivity : ComponentActivity() {
             val smartId = uriString.removePrefix(MainViewModel.SMART_PREFIX)
             SMART_PLAYLIST_PREFIX + Uri.encode(smartId)
         } else {
-            "playlist:$uriString"
+            "playlist:" + playlistShortId(uriString)
         }
     }
 
@@ -970,7 +971,7 @@ class MainActivity : ComponentActivity() {
             val smartId = uriString.removePrefix(MainViewModel.SMART_PREFIX)
             SMART_PLAYLIST_PREFIX + Uri.encode(smartId)
         } else {
-            PLAYLIST_URI_PREFIX + Uri.encode(uriString)
+            PLAYLIST_SHORT_PREFIX + playlistShortId(uriString)
         }
         return ACTION_SHUFFLE_PREFIX + listKey
     }

--- a/shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
@@ -1083,7 +1083,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
             while (playlistShortIds.containsKey(shortId) &&
                    playlistShortIds[shortId] != playlist.uriString) {
                 attempt++
-                shortId = (playlist.uriString.hashCode().toUInt() + attempt.toUInt()).toString(36)
+                shortId = playlistShortId(playlist.uriString + attempt)
             }
             playlistShortIds[shortId] = playlist.uriString
             uriToShortId[playlist.uriString] = shortId

--- a/shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
@@ -205,6 +205,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
     internal val mediaCacheService = MediaCacheService()
     private val playlistService = PlaylistService()
     private val playlistShortIds = mutableMapOf<String, String>() // shortId -> uriString
+    private val uriToShortId = mutableMapOf<String, String>() // uriString -> shortId
     private var currentFileInfo: MediaFileInfo? = null
     private var currentMediaId: String? = null
     private lateinit var audioManager: AudioManager
@@ -1075,6 +1076,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
 
     private fun rebuildPlaylistShortIds() {
         playlistShortIds.clear()
+        uriToShortId.clear()
         for (playlist in mediaCacheService.discoveredPlaylists) {
             var shortId = playlistShortId(playlist.uriString)
             var attempt = 0
@@ -1084,14 +1086,14 @@ class MyMusicService : MediaBrowserServiceCompat() {
                 shortId = (playlist.uriString.hashCode().toUInt() + attempt.toUInt()).toString(36)
             }
             playlistShortIds[shortId] = playlist.uriString
+            uriToShortId[playlist.uriString] = shortId
         }
     }
 
     @VisibleForTesting
     internal fun playlistEntriesForBrowse(discoveredPlaylists: List<PlaylistInfo>): List<PlaylistBrowseEntry> {
         val discoveredEntries = discoveredPlaylists.map { playlist ->
-            val shortId = playlistShortIds.entries
-                .firstOrNull { it.value == playlist.uriString }?.key
+            val shortId = uriToShortId[playlist.uriString]
                 ?: playlistShortId(playlist.uriString)
             PlaylistBrowseEntry(
                 mediaId = PLAYLIST_PREFIX + shortId,
@@ -2028,9 +2030,8 @@ class MyMusicService : MediaBrowserServiceCompat() {
     }
 
     private suspend fun handlePlayPlaylist(resolvedMediaId: String) {
-        val shortIdOrUri = resolvedMediaId.removePrefix(PLAYLIST_PREFIX)
-        val playlistUri = playlistShortIds[shortIdOrUri]
-            ?: Uri.decode(shortIdOrUri) // fallback for legacy full-URI format
+        val shortId = resolvedMediaId.removePrefix(PLAYLIST_PREFIX)
+        val playlistUri = playlistShortIds[shortId] ?: return
         val playlistInfo = mediaCacheService.discoveredPlaylists.firstOrNull {
             it.uriString == playlistUri
         }

--- a/shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
@@ -66,7 +66,6 @@ class MyMusicService : MediaBrowserServiceCompat() {
         private const val SEARCH_ID = "search"
         private const val PLAYLIST_PREFIX = "playlist:"
         private const val SMART_PLAYLIST_PREFIX = "smart_playlist:"
-        private const val PLAYLIST_URI_PREFIX = "playlist_uri:"
         private const val PLAYLIST_SHORT_PREFIX = "pl:"
         private const val ALBUM_PREFIX = "album:"
         private const val GENRE_PREFIX = "genre:"
@@ -760,12 +759,12 @@ class MyMusicService : MediaBrowserServiceCompat() {
             )
         }
         if (parentId.startsWith(PLAYLIST_PREFIX)) {
-            val playlistUri = Uri.decode(parentId.removePrefix(PLAYLIST_PREFIX))
+            val shortId = parentId.removePrefix(PLAYLIST_PREFIX)
+            val playlistUri = playlistShortIds[shortId] ?: return mutableListOf()
             val songs = enrichFromCache(
                 playlistService.readPlaylist(this, Uri.parse(playlistUri))
             )
             val songIconUri = resourceIconUri(R.drawable.ic_album_placeholder)
-            val shortId = playlistShortIds.entries.firstOrNull { it.value == playlistUri }?.key ?: ""
             return buildSongListItems(songs, PLAYLIST_SHORT_PREFIX + shortId, songIconUri)
         }
         if (parentId.startsWith(ALBUM_PREFIX)) {
@@ -1077,7 +1076,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
     private fun rebuildPlaylistShortIds() {
         playlistShortIds.clear()
         for (playlist in mediaCacheService.discoveredPlaylists) {
-            var shortId = playlist.uriString.hashCode().toUInt().toString(36)
+            var shortId = playlistShortId(playlist.uriString)
             var attempt = 0
             while (playlistShortIds.containsKey(shortId) &&
                    playlistShortIds[shortId] != playlist.uriString) {
@@ -1091,8 +1090,11 @@ class MyMusicService : MediaBrowserServiceCompat() {
     @VisibleForTesting
     internal fun playlistEntriesForBrowse(discoveredPlaylists: List<PlaylistInfo>): List<PlaylistBrowseEntry> {
         val discoveredEntries = discoveredPlaylists.map { playlist ->
+            val shortId = playlistShortIds.entries
+                .firstOrNull { it.value == playlist.uriString }?.key
+                ?: playlistShortId(playlist.uriString)
             PlaylistBrowseEntry(
-                mediaId = PLAYLIST_PREFIX + Uri.encode(playlist.uriString),
+                mediaId = PLAYLIST_PREFIX + shortId,
                 title = playlist.displayName.removeSuffix(".m3u")
             )
         }
@@ -1933,16 +1935,6 @@ class MyMusicService : MediaBrowserServiceCompat() {
                     )
                 )
             }
-            listKey.startsWith(PLAYLIST_URI_PREFIX) -> {
-                val playlistUri =
-                    Uri.decode(listKey.removePrefix(PLAYLIST_URI_PREFIX))
-                enrichFromCache(
-                    playlistService.readPlaylist(
-                        this,
-                        Uri.parse(playlistUri)
-                    )
-                )
-            }
             listKey.startsWith(SMART_PLAYLIST_PREFIX) -> {
                 val smartId = Uri.decode(listKey.removePrefix(SMART_PLAYLIST_PREFIX))
                 resolveSmartPlaylistTracksById(smartId) ?: emptyList()
@@ -2006,9 +1998,6 @@ class MyMusicService : MediaBrowserServiceCompat() {
                     .firstOrNull { it.uriString == uri }
                     ?.displayName ?: "Playlist"
             }
-            listKey.startsWith(PLAYLIST_URI_PREFIX) -> {
-                Uri.decode(listKey.removePrefix(PLAYLIST_URI_PREFIX))
-            }
             listKey.startsWith(SMART_PLAYLIST_PREFIX) -> {
                 val smartId = Uri.decode(listKey.removePrefix(SMART_PLAYLIST_PREFIX))
                 smartPlaylistTitleFromId(smartId)
@@ -2039,7 +2028,9 @@ class MyMusicService : MediaBrowserServiceCompat() {
     }
 
     private suspend fun handlePlayPlaylist(resolvedMediaId: String) {
-        val playlistUri = Uri.decode(resolvedMediaId.removePrefix(PLAYLIST_PREFIX))
+        val shortIdOrUri = resolvedMediaId.removePrefix(PLAYLIST_PREFIX)
+        val playlistUri = playlistShortIds[shortIdOrUri]
+            ?: Uri.decode(shortIdOrUri) // fallback for legacy full-URI format
         val playlistInfo = mediaCacheService.discoveredPlaylists.firstOrNull {
             it.uriString == playlistUri
         }

--- a/shared/src/main/java/com/example/mymediaplayer/shared/PlaylistInfo.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/PlaylistInfo.kt
@@ -4,3 +4,7 @@ data class PlaylistInfo(
     val uriString: String,
     val displayName: String
 )
+
+/** Deterministic short hash for use in mediaIds (avoids long content:// URIs). */
+fun playlistShortId(uriString: String): String =
+    uriString.hashCode().toUInt().toString(36)

--- a/shared/src/test/java/com/example/mymediaplayer/shared/MyMusicServiceTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/MyMusicServiceTest.kt
@@ -379,6 +379,9 @@ class MyMusicServiceTest {
         val id2 = playlistShortId(uri2)
         assertTrue("Short ID '$id1' should be under 10 chars", id1.length < 10)
         assertTrue("Short ID '$id2' should be under 10 chars", id2.length < 10)
+        // Determinism: same URI always produces same short ID
+        assertEquals("Short ID must be deterministic", id1, playlistShortId(uri1))
+        // Distinctness: different URIs must not collide
         assertNotEquals("Different URIs should produce different short IDs", id1, id2)
     }
 }

--- a/shared/src/test/java/com/example/mymediaplayer/shared/MyMusicServiceTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/MyMusicServiceTest.kt
@@ -373,8 +373,8 @@ class MyMusicServiceTest {
     @Test
     fun playlistShortId_isDeterministicAndShort() {
         val uri = "content://com.android.externalstorage.documents/tree/primary%3AMusic/document/primary%3AMusic%2Fplaylist.m3u"
-        val shortId = uri.hashCode().toUInt().toString(36)
+        val shortId = playlistShortId(uri)
         assertTrue("Short ID '$shortId' should be under 10 chars", shortId.length < 10)
-        assertEquals(shortId, uri.hashCode().toUInt().toString(36))
+        assertEquals(shortId, playlistShortId(uri))
     }
 }

--- a/shared/src/test/java/com/example/mymediaplayer/shared/MyMusicServiceTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/MyMusicServiceTest.kt
@@ -6,6 +6,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -371,10 +372,13 @@ class MyMusicServiceTest {
     }
 
     @Test
-    fun playlistShortId_isDeterministicAndShort() {
-        val uri = "content://com.android.externalstorage.documents/tree/primary%3AMusic/document/primary%3AMusic%2Fplaylist.m3u"
-        val shortId = playlistShortId(uri)
-        assertTrue("Short ID '$shortId' should be under 10 chars", shortId.length < 10)
-        assertEquals(shortId, playlistShortId(uri))
+    fun playlistShortId_isShortAndDistinct() {
+        val uri1 = "content://com.android.externalstorage.documents/tree/primary%3AMusic/document/primary%3AMusic%2Fplaylist.m3u"
+        val uri2 = "content://com.android.externalstorage.documents/tree/primary%3AMusic/document/primary%3AMusic%2Fother.m3u"
+        val id1 = playlistShortId(uri1)
+        val id2 = playlistShortId(uri2)
+        assertTrue("Short ID '$id1' should be under 10 chars", id1.length < 10)
+        assertTrue("Short ID '$id2' should be under 10 chars", id2.length < 10)
+        assertNotEquals("Different URIs should produce different short IDs", id1, id2)
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #132. Completes the short ID migration:

- Extracted `playlistShortId()` to shared `PlaylistInfo.kt` so both service and phone compute the same hash
- Browse mediaIds for discovered playlists now use short IDs (prevents potential issues with very long playlist paths)
- `getPlaylistMediaId` and `getPlaylistShuffleMediaId` in MainActivity now use short IDs
- Removed `PLAYLIST_URI_PREFIX` fallback branches and dead constant from the service

## Test plan

- [ ] Phone-initiated playlist play still works
- [ ] Phone-initiated playlist shuffle still works
- [ ] Android Auto playlist browsing and play/shuffle still work
- [x] All unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)