### PR TITLE
🧹 Remove unused import in NetworkQualityCheckerTest

### DIFF
--- a/shared/src/test/java/com/example/mymediaplayer/shared/NetworkQualityCheckerTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/NetworkQualityCheckerTest.kt
@@ -6,7 +6,6 @@ import android.net.Network
 import android.net.NetworkCapabilities
 import androidx.test.core.app.ApplicationProvider
 import kotlinx.coroutines.runBlocking
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test


### PR DESCRIPTION
🎯 **What:** Removed an unused import (`import org.junit.After`) from `NetworkQualityCheckerTest.kt`.
💡 **Why:** To improve code cleanliness and maintainability by removing unnecessary dependencies and dead code.
✅ **Verification:** Ran `./gradlew :shared:testDebugUnitTest` and `./gradlew :shared:lintDebug` to confirm tests still pass and no new lint issues were introduced.
✨ **Result:** A cleaner test file with no unused imports.

---
*PR created automatically by Jules for task [2903364501685155091](https://jules.google.com/task/2903364501685155091) started by @kimptoc*