### PR TITLE
🔒 Fix App Allows Backup vulnerability

### DIFF
--- a/automotive/src/main/AndroidManifest.xml
+++ b/automotive/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:appCategory="audio"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
     <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
🎯 **What:** Disabled Android `allowBackup` in `mobile` and `automotive` `AndroidManifest.xml` files.
⚠️ **Risk:** Allowing backups can lead to potential exposure of sensitive application data, including shared preferences and tokens, to unauthorized users via cloud backups or ADB backups, expanding the attack surface.
🛡️ **Solution:** Set `android:allowBackup="false"` in both `mobile` and `automotive` manifests to ensure app data is explicitly not backed up.

---
*PR created automatically by Jules for task [2797922749629790810](https://jules.google.com/task/2797922749629790810) started by @kimptoc*