### PR TITLE
🧪 Add test for getFileIndexByUri in MediaCacheService

### DIFF
--- a/shared/src/test/java/com/example/mymediaplayer/shared/MediaCacheServiceTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/MediaCacheServiceTest.kt
@@ -109,4 +109,19 @@ class MediaCacheServiceTest {
         assertTrue(service.isSupportedPlaylistFile("playlist.txt", "audio/x-mpegurl"))
         assertFalse(service.isSupportedAudioFile("playlist.m3u", "audio/x-mpegurl"))
     }
+
+    @Test
+    fun getFileIndexByUri_returnsPopulatedMap() {
+        val service = MediaCacheService()
+        val file1 = MediaFileInfo(uriString = "uri1", displayName = "file1", sizeBytes = 100L)
+        val file2 = MediaFileInfo(uriString = "uri2", displayName = "file2", sizeBytes = 200L)
+
+        service.addFile(file1)
+        service.addFile(file2)
+
+        val index = service.getFileIndexByUri()
+        assertEquals(2, index.size)
+        assertEquals(file1, index["uri1"])
+        assertEquals(file2, index["uri2"])
+    }
 }


### PR DESCRIPTION
🎯 **What:** Added a missing unit test for `getFileIndexByUri()` in `MediaCacheService`.
📊 **Coverage:** Tests that `getFileIndexByUri()` correctly returns a map populated with previously added files.
✨ **Result:** Improved test coverage and reliability for cache retrieval logic.

---
*PR created automatically by Jules for task [11051254021410220195](https://jules.google.com/task/11051254021410220195) started by @kimptoc*