### PR TITLE
🧹 Refactor overly complex getPrefs function in MyMusicService.kt

### DIFF
--- a/shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
@@ -122,34 +122,44 @@ class MyMusicService : MediaBrowserServiceCompat() {
             val masterKey = androidx.security.crypto.MasterKey.Builder(context).setKeyScheme(androidx.security.crypto.MasterKey.KeyScheme.AES256_GCM).build()
             val encryptedPrefs = androidx.security.crypto.EncryptedSharedPreferences.create(context, "${PREFS_NAME}_encrypted", masterKey, androidx.security.crypto.EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV, androidx.security.crypto.EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM)
             val standardPrefsFile = File(context.applicationInfo.dataDir, "shared_prefs/${PREFS_NAME}.xml")
+
             if (standardPrefsFile.exists() && !encryptedPrefs.getBoolean("migration_completed", false)) {
-                val standardPrefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-                val editor = encryptedPrefs.edit()
-                for ((key, value) in standardPrefs.all) {
-                    when (value) {
-                        is String -> editor.putString(key, value)
-                        is Int -> editor.putInt(key, value)
-                        is Boolean -> editor.putBoolean(key, value)
-                        is Long -> editor.putLong(key, value)
-                        is Float -> editor.putFloat(key, value)
-                        is Set<*> -> {
-                            @Suppress("UNCHECKED_CAST")
-                            editor.putStringSet(key, value as Set<String>)
-                        }
-                    }
-                }
-                try {
-                    @Suppress("ApplySharedPref")
-                    editor.putBoolean("migration_completed", true).commit()
-                    @Suppress("ApplySharedPref")
-                    standardPrefs.edit().clear().commit()
-                    standardPrefsFile.delete()
-                } catch (e: Exception) {
-                    // Log error - migration will retry on next app launch
-                }
+                migratePreferences(context, encryptedPrefs, standardPrefsFile)
             }
+
             prefsInstance = encryptedPrefs
             return encryptedPrefs
+        }
+
+        private fun migratePreferences(
+            context: Context,
+            encryptedPrefs: android.content.SharedPreferences,
+            standardPrefsFile: File
+        ) {
+            val standardPrefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            val editor = encryptedPrefs.edit()
+            for ((key, value) in standardPrefs.all) {
+                when (value) {
+                    is String -> editor.putString(key, value)
+                    is Int -> editor.putInt(key, value)
+                    is Boolean -> editor.putBoolean(key, value)
+                    is Long -> editor.putLong(key, value)
+                    is Float -> editor.putFloat(key, value)
+                    is Set<*> -> {
+                        @Suppress("UNCHECKED_CAST")
+                        editor.putStringSet(key, value as Set<String>)
+                    }
+                }
+            }
+            try {
+                @Suppress("ApplySharedPref")
+                editor.putBoolean("migration_completed", true).commit()
+                @Suppress("ApplySharedPref")
+                standardPrefs.edit().clear().commit()
+                standardPrefsFile.delete()
+            } catch (e: Exception) {
+                // Log error - migration will retry on next app launch
+            }
         }
         private const val ACTION_MEDIA_PLAY_FROM_SEARCH = "android.media.action.MEDIA_PLAY_FROM_SEARCH"
 


### PR DESCRIPTION
🎯 **What:** Extracted the standard SharedPreferences migration logic into a separate `migratePreferences` helper function.
💡 **Why:** The original `getPrefs` function handled too many responsibilities (instance tracking, encrypted preferences initialization, and complete standard preferences migration). Extracting the migration logic improves readability and separation of concerns.
✅ **Verification:** Verified compilation, lint, and unit tests using `./gradlew :shared:testDebugUnitTest :shared:lintDebug`.
✨ **Result:** Improved code maintainability and reduced complexity of the `getPrefs` method.

---
*PR created automatically by Jules for task [15259127611839965102](https://jules.google.com/task/15259127611839965102) started by @kimptoc*