### PR TITLE
🧪 Add tests for cancelAll in AnnouncementPreGenerator

### DIFF
--- a/shared/src/test/java/com/example/mymediaplayer/shared/AnnouncementPreGeneratorTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/AnnouncementPreGeneratorTest.kt
@@ -58,4 +58,56 @@ class AnnouncementPreGeneratorTest {
 
         assertNull(result)
     }
+
+    @Test
+    fun cancelAll_cancelsIncompleteDeferreds() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val preGen = AnnouncementPreGenerator(context, TestScope(this.testScheduler))
+
+        val cacheField = AnnouncementPreGenerator::class.java.getDeclaredField("cache")
+        cacheField.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        val cache = cacheField.get(preGen) as ConcurrentHashMap<Any, Deferred<File?>>
+
+        val cacheKeyClass = Class.forName("com.example.mymediaplayer.shared.AnnouncementPreGenerator\$CacheKey")
+        val constructor = cacheKeyClass.getDeclaredConstructor(String::class.java, Boolean::class.java)
+        constructor.isAccessible = true
+        val key = constructor.newInstance("test_uri", true)
+
+        val deferred = CompletableDeferred<File?>()
+        cache[key] = deferred
+
+        preGen.cancelAll()
+
+        org.junit.Assert.assertTrue(cache.isEmpty())
+        org.junit.Assert.assertTrue(deferred.isCancelled)
+    }
+
+    @Test
+    fun cancelAll_deletesCompletedFiles() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val preGen = AnnouncementPreGenerator(context, TestScope(this.testScheduler))
+
+        val cacheField = AnnouncementPreGenerator::class.java.getDeclaredField("cache")
+        cacheField.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        val cache = cacheField.get(preGen) as ConcurrentHashMap<Any, Deferred<File?>>
+
+        val cacheKeyClass = Class.forName("com.example.mymediaplayer.shared.AnnouncementPreGenerator\$CacheKey")
+        val constructor = cacheKeyClass.getDeclaredConstructor(String::class.java, Boolean::class.java)
+        constructor.isAccessible = true
+        val key = constructor.newInstance("test_uri2", true)
+
+        val file = File.createTempFile("test", ".mp3").apply { setReadable(false, false); setWritable(false, false); setExecutable(false, false); setReadable(true, true); setWritable(true, true); }
+        org.junit.Assert.assertTrue(file.exists())
+
+        val deferred = CompletableDeferred<File?>()
+        deferred.complete(file)
+        cache[key] = deferred
+
+        preGen.cancelAll()
+
+        org.junit.Assert.assertTrue(cache.isEmpty())
+        org.junit.Assert.assertFalse(file.exists())
+    }
 }


### PR DESCRIPTION
🎯 **What:** The `cancelAll` method in `AnnouncementPreGenerator` lacked test coverage. The issue stated the functionality needs a simple test to verify job cancellation and cache clearing.

📊 **Coverage:** Two new test cases were added to `AnnouncementPreGeneratorTest.kt`:
1.  `cancelAll_cancelsIncompleteDeferreds`: Simulates an incomplete caching job using `CompletableDeferred` and verifies that `cancelAll()` clears the cache and cancels the job.
2.  `cancelAll_deletesCompletedFiles`: Simulates a completed caching job with an actual file on disk, and verifies that `cancelAll()` clears the cache and successfully deletes the file.

✨ **Result:** Test coverage for `AnnouncementPreGenerator` is improved, explicitly guarding the cancellation semantics of background audio generation jobs.

---
*PR created automatically by Jules for task [10202808033762654816](https://jules.google.com/task/10202808033762654816) started by @kimptoc*