### PR TITLE
🔒 Require BIND_MEDIA_BROWSER_SERVICE for MyMusicService

### DIFF
--- a/shared/src/main/AndroidManifest.xml
+++ b/shared/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         <service
             android:name="com.example.mymediaplayer.shared.MyMusicService"
             android:exported="true"
+            android:permission="android.permission.BIND_MEDIA_BROWSER_SERVICE"
             android:foregroundServiceType="mediaPlayback">
             <intent-filter>
                 <action android:name="android.media.browse.MediaBrowserService" />


### PR DESCRIPTION
🎯 **What:**
Added the `android:permission="android.permission.BIND_MEDIA_BROWSER_SERVICE"` attribute to the `<service>` tag for `MyMusicService` in `shared/src/main/AndroidManifest.xml`.

⚠️ **Risk:**
Without this permission, the exported `MediaBrowserService` allows any application on the device to connect to the service without restriction. This could allow malicious apps to access media browsing data or manipulate playback controls.

🛡️ **Solution:**
Requiring the `android.permission.BIND_MEDIA_BROWSER_SERVICE` ensures that only authorized clients (such as Android Auto or valid media clients) that have been granted this system permission can bind to and interact with the service.

---
*PR created automatically by Jules for task [4160577279340767112](https://jules.google.com/task/4160577279340767112) started by @kimptoc*