### PR TITLE
🧪 [Add tests for MediaCacheService.enrichGenresFromMediaStore]

### DIFF
--- a/shared/src/test/java/com/example/mymediaplayer/shared/MediaCacheServiceTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/MediaCacheServiceTest.kt
@@ -3,8 +3,11 @@ package com.example.mymediaplayer.shared
 import android.content.Context
 import android.net.Uri
 import android.provider.DocumentsContract
+import android.provider.MediaStore
 import androidx.test.core.app.ApplicationProvider
 import kotlinx.coroutines.Job
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.fakes.RoboCursor
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
@@ -108,5 +111,119 @@ class MediaCacheServiceTest {
         assertTrue(service.isSupportedPlaylistFile("playlist.m3u", null))
         assertTrue(service.isSupportedPlaylistFile("playlist.txt", "audio/x-mpegurl"))
         assertFalse(service.isSupportedAudioFile("playlist.m3u", "audio/x-mpegurl"))
+    }
+
+    @Test
+    fun enrichGenresFromMediaStore_enrichesGenresCorrectly() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val shadowResolver = shadowOf(context.contentResolver)
+
+        val mediaCursor = RoboCursor()
+        mediaCursor.setColumnNames(listOf(MediaStore.Audio.Media._ID, MediaStore.Audio.Media.DISPLAY_NAME))
+        mediaCursor.setResults(arrayOf(arrayOf(1L, "song1.mp3")))
+        shadowResolver.setCursor(MediaStore.Audio.Media.EXTERNAL_CONTENT_URI, mediaCursor)
+
+        val genresCursor = RoboCursor()
+        genresCursor.setColumnNames(listOf(MediaStore.Audio.Genres._ID, MediaStore.Audio.Genres.NAME))
+        genresCursor.setResults(arrayOf(arrayOf(100L, "Rock")))
+        shadowResolver.setCursor(MediaStore.Audio.Genres.EXTERNAL_CONTENT_URI, genresCursor)
+
+        val membersCursor = RoboCursor()
+        membersCursor.setColumnNames(listOf(MediaStore.Audio.Genres.Members.AUDIO_ID))
+        membersCursor.setResults(arrayOf(arrayOf(1L)))
+        val membersUri = MediaStore.Audio.Genres.Members.getContentUri("external", 100L)
+        shadowResolver.setCursor(membersUri, membersCursor)
+
+        val service = MediaCacheService()
+        service.addFile(
+            MediaFileInfo(
+                uriString = "content://test/song1",
+                displayName = "song1.mp3",
+                sizeBytes = 100L,
+                genre = null // Missing genre
+            )
+        )
+
+        service.enrichGenresFromMediaStore(context)
+
+        assertEquals("Rock", service.cachedFiles.first().genre)
+    }
+
+    @Test
+    fun enrichGenresFromMediaStore_doesNotOverwriteExistingGenres() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val shadowResolver = shadowOf(context.contentResolver)
+
+        val mediaCursor = RoboCursor()
+        mediaCursor.setColumnNames(listOf(MediaStore.Audio.Media._ID, MediaStore.Audio.Media.DISPLAY_NAME))
+        mediaCursor.setResults(arrayOf(arrayOf(1L, "song1.mp3")))
+        shadowResolver.setCursor(MediaStore.Audio.Media.EXTERNAL_CONTENT_URI, mediaCursor)
+
+        val genresCursor = RoboCursor()
+        genresCursor.setColumnNames(listOf(MediaStore.Audio.Genres._ID, MediaStore.Audio.Genres.NAME))
+        genresCursor.setResults(arrayOf(arrayOf(100L, "Pop")))
+        shadowResolver.setCursor(MediaStore.Audio.Genres.EXTERNAL_CONTENT_URI, genresCursor)
+
+        val membersCursor = RoboCursor()
+        membersCursor.setColumnNames(listOf(MediaStore.Audio.Genres.Members.AUDIO_ID))
+        membersCursor.setResults(arrayOf(arrayOf(1L)))
+        val membersUri = MediaStore.Audio.Genres.Members.getContentUri("external", 100L)
+        shadowResolver.setCursor(membersUri, membersCursor)
+
+        val service = MediaCacheService()
+        service.addFile(
+            MediaFileInfo(
+                uriString = "content://test/song1",
+                displayName = "song1.mp3",
+                sizeBytes = 100L,
+                genre = "Rock" // Existing genre
+            )
+        )
+
+        service.enrichGenresFromMediaStore(context)
+
+        assertEquals("Rock", service.cachedFiles.first().genre)
+    }
+
+    @Test
+    fun enrichGenresFromMediaStore_handlesConflictingGenres() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val shadowResolver = shadowOf(context.contentResolver)
+
+        val mediaCursor = RoboCursor()
+        mediaCursor.setColumnNames(listOf(MediaStore.Audio.Media._ID, MediaStore.Audio.Media.DISPLAY_NAME))
+        mediaCursor.setResults(arrayOf(arrayOf(1L, "song1.mp3")))
+        shadowResolver.setCursor(MediaStore.Audio.Media.EXTERNAL_CONTENT_URI, mediaCursor)
+
+        val genresCursor = RoboCursor()
+        genresCursor.setColumnNames(listOf(MediaStore.Audio.Genres._ID, MediaStore.Audio.Genres.NAME))
+        genresCursor.setResults(arrayOf(arrayOf(100L, "Rock"), arrayOf(101L, "Electronic")))
+        shadowResolver.setCursor(MediaStore.Audio.Genres.EXTERNAL_CONTENT_URI, genresCursor)
+
+        val membersCursor1 = RoboCursor()
+        membersCursor1.setColumnNames(listOf(MediaStore.Audio.Genres.Members.AUDIO_ID))
+        membersCursor1.setResults(arrayOf(arrayOf(1L)))
+        val membersUri1 = MediaStore.Audio.Genres.Members.getContentUri("external", 100L)
+        shadowResolver.setCursor(membersUri1, membersCursor1)
+
+        val membersCursor2 = RoboCursor()
+        membersCursor2.setColumnNames(listOf(MediaStore.Audio.Genres.Members.AUDIO_ID))
+        membersCursor2.setResults(arrayOf(arrayOf(1L)))
+        val membersUri2 = MediaStore.Audio.Genres.Members.getContentUri("external", 101L)
+        shadowResolver.setCursor(membersUri2, membersCursor2)
+
+        val service = MediaCacheService()
+        service.addFile(
+            MediaFileInfo(
+                uriString = "content://test/song1",
+                displayName = "song1.mp3",
+                sizeBytes = 100L,
+                genre = null
+            )
+        )
+
+        service.enrichGenresFromMediaStore(context)
+
+        assertEquals(null, service.cachedFiles.first().genre)
     }
 }


### PR DESCRIPTION
- 🎯 **What:** The untested `enrichGenresFromMediaStore` function in `MediaCacheService.kt` required tests covering its MediaStore queries using mocks.
- 📊 **Coverage:** Added tests to cover scenarios where genres are successfully queried and enriched, existing genres are not overwritten, and conflicting genres are handled properly without applying a genre.
- ✨ **Result:** Improved test coverage and reliability for media genre metadata enrichment.

---
*PR created automatically by Jules for task [7541023653403917962](https://jules.google.com/task/7541023653403917962) started by @kimptoc*