### PR TITLE
🧹 Refactor overly complex scanWholeDevice function

### DIFF
--- a/new.txt
+++ b/new.txt
@@ -1,0 +1,158 @@
+
+    suspend fun scanWholeDevice(
+        context: Context,
+        maxFiles: Int = MAX_CACHE_SIZE,
+        onProgress: ((songsFound: Int, foldersScanned: Int) -> Unit)? = null
+    ): ScanStats = kotlinx.coroutines.withContext(Dispatchers.IO) {
+        clearCache()
+        maxFileLimit = maxFiles.coerceAtLeast(1)
+        foldersScanned = 0
+        songsFound = 0
+        val startTime = android.os.SystemClock.elapsedRealtime()
+        val extensionCounts = mutableMapOf<String, Int>()
+        val out = mutableListOf<MediaFileInfo>()
+        val outIds = mutableListOf<Long>()
+
+        queryMediaStore(context, out, outIds, extensionCounts, onProgress)
+        enrichGenresForOlderSdks(context, out, outIds)
+        updateCacheFromScan(out)
+
+        onProgress?.invoke(out.size, 0)
+        val durationMs = android.os.SystemClock.elapsedRealtime() - startTime
+        ScanStats(
+            durationMs = durationMs,
+            foldersScanned = 0,
+            songsFound = out.size,
+            extensionCounts = extensionCounts.toMap(),
+            skippedReasons = emptyMap(),
+            deepScan = false,
+            probedCandidates = 0
+        )
+    }
+
+    private fun queryMediaStore(
+        context: Context,
+        out: MutableList<MediaFileInfo>,
+        outIds: MutableList<Long>,
+        extensionCounts: MutableMap<String, Int>,
+        onProgress: ((songsFound: Int, foldersScanned: Int) -> Unit)?
+    ) {
+        val projectionList = mutableListOf(
+            MediaStore.Audio.Media._ID,
+            MediaStore.Audio.Media.DISPLAY_NAME,
+            MediaStore.Audio.Media.SIZE,
+            MediaStore.Audio.Media.TITLE,
+            MediaStore.Audio.Media.ARTIST,
+            MediaStore.Audio.Media.ALBUM,
+            MediaStore.Audio.Media.RELATIVE_PATH,
+            MediaStore.Audio.Media.DURATION,
+            MediaStore.Audio.Media.YEAR,
+            MediaStore.Audio.Media.DATE_ADDED
+        )
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
+            projectionList.add(MediaStore.Audio.Media.GENRE)
+        }
+        val projection = projectionList.toTypedArray()
+        val sortOrder = "${MediaStore.Audio.Media.DATE_ADDED} DESC"
+        val selection = "${MediaStore.Audio.Media.IS_MUSIC} != 0"
+
+        context.contentResolver.query(
+            MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
+            projection,
+            selection,
+            null,
+            sortOrder
+        )?.use { cursor ->
+            val idIndex = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media._ID)
+            val nameIndex = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.DISPLAY_NAME)
+            val sizeIndex = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.SIZE)
+            val titleIndex = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.TITLE)
+            val artistIndex = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.ARTIST)
+            val albumIndex = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.ALBUM)
+            val relativePathIndex = cursor.getColumnIndex(MediaStore.Audio.Media.RELATIVE_PATH)
+            val durationIndex = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.DURATION)
+            val yearIndex = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.YEAR)
+            val addedIndex = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.DATE_ADDED)
+            val genreIndex = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
+                cursor.getColumnIndex(MediaStore.Audio.Media.GENRE)
+            } else {
+                -1
+            }
+            while (cursor.moveToNext() && out.size < maxFileLimit) {
+                val id = cursor.getLong(idIndex)
+                val uri = ContentUris.withAppendedId(
+                    MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
+                    id
+                )
+                val displayName = cursor.getString(nameIndex) ?: uri.toString()
+                val sizeBytes = if (cursor.isNull(sizeIndex)) 0L else cursor.getLong(sizeIndex)
+                val title = cursor.getString(titleIndex)
+                val artist = cursor.getString(artistIndex)
+                val album = cursor.getString(albumIndex)
+                val relativePath = if (relativePathIndex >= 0 && !cursor.isNull(relativePathIndex)) {
+                    cursor.getString(relativePathIndex)
+                } else {
+                    null
+                }
+                val durationMs = if (cursor.isNull(durationIndex)) null else cursor.getLong(durationIndex)
+                val year = if (cursor.isNull(yearIndex)) null else cursor.getInt(yearIndex)
+                val addedAtMs = if (cursor.isNull(addedIndex)) {
+                    null
+                } else {
+                    cursor.getLong(addedIndex) * 1000L
+                }
+                val osGenre = if (genreIndex >= 0 && !cursor.isNull(genreIndex)) {
+                    cursor.getString(genreIndex)
+                } else null
+                out.add(
+                    MediaFileInfo(
+                        uriString = uri.toString(),
+                        displayName = displayName,
+                        sizeBytes = sizeBytes,
+                        title = title,
+                        artist = artist,
+                        album = album,
+                        genre = normalizeGenre(osGenre ?: inferGenreFromPath(relativePath)),
+                        durationMs = durationMs,
+                        year = year,
+                        addedAtMs = addedAtMs
+                    )
+                )
+                outIds.add(id)
+                songsFound = out.size
+                val ext = fileExtension(displayName)
+                extensionCounts[ext] = (extensionCounts[ext] ?: 0) + 1
+                if (songsFound % 200 == 0 || songsFound == 1) {
+                    onProgress?.invoke(songsFound, 0)
+                }
+            }
+        }
+    }
+
+    private fun enrichGenresForOlderSdks(
+        context: Context,
+        out: MutableList<MediaFileInfo>,
+        outIds: MutableList<Long>
+    ) {
+        if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.R) {
+            val genresByAudioId = loadWholeDriveGenres(context, outIds.toSet())
+            if (genresByAudioId.isNotEmpty()) {
+                for (index in out.indices) {
+                    val audioId = outIds[index]
+                    val mappedGenre = genresByAudioId[audioId] ?: continue
+                    out[index] = out[index].copy(genre = normalizeGenre(mappedGenre))
+                }
+            }
+        }
+    }
+
+    private fun updateCacheFromScan(out: List<MediaFileInfo>) {
+        synchronized(cacheLock) {
+            _cachedFiles.clear()
+            _cachedFiles.addAll(out)
+            _cachedFilesByUri.clear()
+            _cachedFilesByUri.putAll(out.associateBy { it.uriString })
+            _discoveredPlaylists.clear()
+            albumArtistIndexed = false
+        }
+    }

--- a/old.txt
+++ b/old.txt
@@ -1,0 +1,135 @@
+
+    suspend fun scanWholeDevice(
+        context: Context,
+        maxFiles: Int = MAX_CACHE_SIZE,
+        onProgress: ((songsFound: Int, foldersScanned: Int) -> Unit)? = null
+    ): ScanStats = kotlinx.coroutines.withContext(Dispatchers.IO) {
+        clearCache()
+        maxFileLimit = maxFiles.coerceAtLeast(1)
+        foldersScanned = 0
+        songsFound = 0
+        val startTime = android.os.SystemClock.elapsedRealtime()
+        val extensionCounts = mutableMapOf<String, Int>()
+        val out = mutableListOf<MediaFileInfo>()
+        val outIds = mutableListOf<Long>()
+
+        val projectionList = mutableListOf(
+            MediaStore.Audio.Media._ID,
+            MediaStore.Audio.Media.DISPLAY_NAME,
+            MediaStore.Audio.Media.SIZE,
+            MediaStore.Audio.Media.TITLE,
+            MediaStore.Audio.Media.ARTIST,
+            MediaStore.Audio.Media.ALBUM,
+            MediaStore.Audio.Media.RELATIVE_PATH,
+            MediaStore.Audio.Media.DURATION,
+            MediaStore.Audio.Media.YEAR,
+            MediaStore.Audio.Media.DATE_ADDED
+        )
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
+            projectionList.add(MediaStore.Audio.Media.GENRE)
+        }
+        val projection = projectionList.toTypedArray()
+        val sortOrder = "${MediaStore.Audio.Media.DATE_ADDED} DESC"
+        val selection = "${MediaStore.Audio.Media.IS_MUSIC} != 0"
+
+        context.contentResolver.query(
+            MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
+            projection,
+            selection,
+            null,
+            sortOrder
+        )?.use { cursor ->
+            val idIndex = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media._ID)
+            val nameIndex = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.DISPLAY_NAME)
+            val sizeIndex = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.SIZE)
+            val titleIndex = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.TITLE)
+            val artistIndex = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.ARTIST)
+            val albumIndex = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.ALBUM)
+            val relativePathIndex = cursor.getColumnIndex(MediaStore.Audio.Media.RELATIVE_PATH)
+            val durationIndex = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.DURATION)
+            val yearIndex = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.YEAR)
+            val addedIndex = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.DATE_ADDED)
+            val genreIndex = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
+                cursor.getColumnIndex(MediaStore.Audio.Media.GENRE)
+            } else {
+                -1
+            }
+            while (cursor.moveToNext() && out.size < maxFileLimit) {
+                val id = cursor.getLong(idIndex)
+                val uri = ContentUris.withAppendedId(
+                    MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
+                    id
+                )
+                val displayName = cursor.getString(nameIndex) ?: uri.toString()
+                val sizeBytes = if (cursor.isNull(sizeIndex)) 0L else cursor.getLong(sizeIndex)
+                val title = cursor.getString(titleIndex)
+                val artist = cursor.getString(artistIndex)
+                val album = cursor.getString(albumIndex)
+                val relativePath = if (relativePathIndex >= 0 && !cursor.isNull(relativePathIndex)) {
+                    cursor.getString(relativePathIndex)
+                } else {
+                    null
+                }
+                val durationMs = if (cursor.isNull(durationIndex)) null else cursor.getLong(durationIndex)
+                val year = if (cursor.isNull(yearIndex)) null else cursor.getInt(yearIndex)
+                val addedAtMs = if (cursor.isNull(addedIndex)) {
+                    null
+                } else {
+                    cursor.getLong(addedIndex) * 1000L
+                }
+                val osGenre = if (genreIndex >= 0 && !cursor.isNull(genreIndex)) {
+                    cursor.getString(genreIndex)
+                } else null
+                out.add(
+                    MediaFileInfo(
+                        uriString = uri.toString(),
+                        displayName = displayName,
+                        sizeBytes = sizeBytes,
+                        title = title,
+                        artist = artist,
+                        album = album,
+                        genre = normalizeGenre(osGenre ?: inferGenreFromPath(relativePath)),
+                        durationMs = durationMs,
+                        year = year,
+                        addedAtMs = addedAtMs
+                    )
+                )
+                outIds.add(id)
+                songsFound = out.size
+                val ext = fileExtension(displayName)
+                extensionCounts[ext] = (extensionCounts[ext] ?: 0) + 1
+                if (songsFound % 200 == 0 || songsFound == 1) {
+                    onProgress?.invoke(songsFound, 0)
+                }
+            }
+        }
+        if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.R) {
+            val genresByAudioId = loadWholeDriveGenres(context, outIds.toSet())
+            if (genresByAudioId.isNotEmpty()) {
+                for (index in out.indices) {
+                    val audioId = outIds[index]
+                    val mappedGenre = genresByAudioId[audioId] ?: continue
+                    out[index] = out[index].copy(genre = normalizeGenre(mappedGenre))
+                }
+            }
+        }
+        synchronized(cacheLock) {
+            _cachedFiles.clear()
+            _cachedFiles.addAll(out)
+            _cachedFilesByUri.clear()
+            _cachedFilesByUri.putAll(out.associateBy { it.uriString })
+            _discoveredPlaylists.clear()
+            albumArtistIndexed = false
+        }
+        onProgress?.invoke(out.size, 0)
+        val durationMs = android.os.SystemClock.elapsedRealtime() - startTime
+        ScanStats(
+            durationMs = durationMs,
+            foldersScanned = 0,
+            songsFound = out.size,
+            extensionCounts = extensionCounts.toMap(),
+            skippedReasons = emptyMap(),
+            deepScan = false,
+            probedCandidates = 0
+        )
+    }

--- a/patch_file.diff
+++ b/patch_file.diff
@@ -1,0 +1,114 @@
+<<<<
+        val projectionList = mutableListOf(
+            MediaStore.Audio.Media._ID,
+            MediaStore.Audio.Media.DISPLAY_NAME,
+            MediaStore.Audio.Media.SIZE,
+            MediaStore.Audio.Media.TITLE,
+            MediaStore.Audio.Media.ARTIST,
+            MediaStore.Audio.Media.ALBUM,
+            MediaStore.Audio.Media.RELATIVE_PATH,
+            MediaStore.Audio.Media.DURATION,
+            MediaStore.Audio.Media.YEAR,
+            MediaStore.Audio.Media.DATE_ADDED
+        )
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
+            projectionList.add(MediaStore.Audio.Media.GENRE)
+        }
+        val projection = projectionList.toTypedArray()
+        val sortOrder = "${MediaStore.Audio.Media.DATE_ADDED} DESC"
+        val selection = "${MediaStore.Audio.Media.IS_MUSIC} != 0"
+
+        context.contentResolver.query(
+            MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
+            projection,
+            selection,
+            null,
+            sortOrder
+        )?.use { cursor ->
+            val idIndex = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media._ID)
+            val nameIndex = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.DISPLAY_NAME)
+            val sizeIndex = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.SIZE)
+            val titleIndex = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.TITLE)
+            val artistIndex = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.ARTIST)
+            val albumIndex = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.ALBUM)
+            val relativePathIndex = cursor.getColumnIndex(MediaStore.Audio.Media.RELATIVE_PATH)
+            val durationIndex = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.DURATION)
+            val yearIndex = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.YEAR)
+            val addedIndex = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.DATE_ADDED)
+            val genreIndex = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
+                cursor.getColumnIndex(MediaStore.Audio.Media.GENRE)
+            } else {
+                -1
+            }
+            while (cursor.moveToNext() && out.size < maxFileLimit) {
+                val id = cursor.getLong(idIndex)
+                val uri = ContentUris.withAppendedId(
+                    MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
+                    id
+                )
+                val displayName = cursor.getString(nameIndex) ?: uri.toString()
+                val sizeBytes = if (cursor.isNull(sizeIndex)) 0L else cursor.getLong(sizeIndex)
+                val title = cursor.getString(titleIndex)
+                val artist = cursor.getString(artistIndex)
+                val album = cursor.getString(albumIndex)
+                val relativePath = if (relativePathIndex >= 0 && !cursor.isNull(relativePathIndex)) {
+                    cursor.getString(relativePathIndex)
+                } else {
+                    null
+                }
+                val durationMs = if (cursor.isNull(durationIndex)) null else cursor.getLong(durationIndex)
+                val year = if (cursor.isNull(yearIndex)) null else cursor.getInt(yearIndex)
+                val addedAtMs = if (cursor.isNull(addedIndex)) {
+                    null
+                } else {
+                    cursor.getLong(addedIndex) * 1000L
+                }
+                val osGenre = if (genreIndex >= 0 && !cursor.isNull(genreIndex)) {
+                    cursor.getString(genreIndex)
+                } else null
+                out.add(
+                    MediaFileInfo(
+                        uriString = uri.toString(),
+                        displayName = displayName,
+                        sizeBytes = sizeBytes,
+                        title = title,
+                        artist = artist,
+                        album = album,
+                        genre = normalizeGenre(osGenre ?: inferGenreFromPath(relativePath)),
+                        durationMs = durationMs,
+                        year = year,
+                        addedAtMs = addedAtMs
+                    )
+                )
+                outIds.add(id)
+                songsFound = out.size
+                val ext = fileExtension(displayName)
+                extensionCounts[ext] = (extensionCounts[ext] ?: 0) + 1
+                if (songsFound % 200 == 0 || songsFound == 1) {
+                    onProgress?.invoke(songsFound, 0)
+                }
+            }
+        }
+        if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.R) {
+            val genresByAudioId = loadWholeDriveGenres(context, outIds.toSet())
+            if (genresByAudioId.isNotEmpty()) {
+                for (index in out.indices) {
+                    val audioId = outIds[index]
+                    val mappedGenre = genresByAudioId[audioId] ?: continue
+                    out[index] = out[index].copy(genre = normalizeGenre(mappedGenre))
+                }
+            }
+        }
+        synchronized(cacheLock) {
+            _cachedFiles.clear()
+            _cachedFiles.addAll(out)
+            _cachedFilesByUri.clear()
+            _cachedFilesByUri.putAll(out.associateBy { it.uriString })
+            _discoveredPlaylists.clear()
+            albumArtistIndexed = false
+        }
+====
+        queryMediaStore(context, out, outIds, extensionCounts, onProgress)
+        enrichGenresForOlderSdks(context, out, outIds)
+        updateCacheFromScan(out)
+>>>>

--- a/shared/src/main/java/com/example/mymediaplayer/shared/MediaCacheService.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/MediaCacheService.kt
@@ -62,6 +62,30 @@ class MediaCacheService {
         val out = mutableListOf<MediaFileInfo>()
         val outIds = mutableListOf<Long>()
 
+        queryMediaStore(context, out, outIds, extensionCounts, onProgress)
+        enrichGenresForOlderSdks(context, out, outIds)
+        updateCacheFromScan(out)
+
+        onProgress?.invoke(out.size, 0)
+        val durationMs = android.os.SystemClock.elapsedRealtime() - startTime
+        ScanStats(
+            durationMs = durationMs,
+            foldersScanned = 0,
+            songsFound = out.size,
+            extensionCounts = extensionCounts.toMap(),
+            skippedReasons = emptyMap(),
+            deepScan = false,
+            probedCandidates = 0
+        )
+    }
+
+    private fun queryMediaStore(
+        context: Context,
+        out: MutableList<MediaFileInfo>,
+        outIds: MutableList<Long>,
+        extensionCounts: MutableMap<String, Int>,
+        onProgress: ((songsFound: Int, foldersScanned: Int) -> Unit)?
+    ) {
         val projectionList = mutableListOf(
             MediaStore.Audio.Media._ID,
             MediaStore.Audio.Media.DISPLAY_NAME,
@@ -152,6 +176,13 @@ class MediaCacheService {
                 }
             }
         }
+    }
+
+    private fun enrichGenresForOlderSdks(
+        context: Context,
+        out: MutableList<MediaFileInfo>,
+        outIds: MutableList<Long>
+    ) {
         if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.R) {
             val genresByAudioId = loadWholeDriveGenres(context, outIds.toSet())
             if (genresByAudioId.isNotEmpty()) {
@@ -162,6 +193,9 @@ class MediaCacheService {
                 }
             }
         }
+    }
+
+    private fun updateCacheFromScan(out: List<MediaFileInfo>) {
         synchronized(cacheLock) {
             _cachedFiles.clear()
             _cachedFiles.addAll(out)
@@ -170,19 +204,7 @@ class MediaCacheService {
             _discoveredPlaylists.clear()
             albumArtistIndexed = false
         }
-        onProgress?.invoke(out.size, 0)
-        val durationMs = android.os.SystemClock.elapsedRealtime() - startTime
-        ScanStats(
-            durationMs = durationMs,
-            foldersScanned = 0,
-            songsFound = out.size,
-            extensionCounts = extensionCounts.toMap(),
-            skippedReasons = emptyMap(),
-            deepScan = false,
-            probedCandidates = 0
-        )
     }
-
     private fun loadWholeDriveGenres(context: Context, audioIds: Set<Long>): Map<Long, String> {
         if (audioIds.isEmpty()) return emptyMap()
         val resolver = context.contentResolver


### PR DESCRIPTION
🎯 **What:** Extracted MediaStore querying, genre enrichment, and cache updating from `scanWholeDevice` into smaller helper methods (`queryMediaStore`, `enrichGenresForOlderSdks`, `updateCacheFromScan`).
💡 **Why:** This drastically reduces the length and cognitive complexity of `scanWholeDevice`, separating the logical steps of data collection, processing, and caching, thus improving maintainability.
✅ **Verification:** Verified by ensuring the module's test suite and lint checks continue to pass locally with `./gradlew :shared:testDebugUnitTest :shared:lintDebug check`.
✨ **Result:** `scanWholeDevice` is now clean and readable. Behavior remains entirely unchanged.

---
*PR created automatically by Jules for task [17782474929273989075](https://jules.google.com/task/17782474929273989075) started by @kimptoc*