### PR TITLE
🧪 Add test for IOException during readPlaylist stream opening

### DIFF
--- a/shared/src/test/java/com/example/mymediaplayer/shared/PlaylistServiceTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/PlaylistServiceTest.kt
@@ -16,6 +16,21 @@ import org.robolectric.Shadows
 class PlaylistServiceTest {
 
     @Test
+    fun readPlaylist_returnsEmptyOnOpenIOException() {
+        val baseContext = ApplicationProvider.getApplicationContext<Context>()
+        val uri = Uri.parse("content://test/playlist.m3u")
+        val shadowResolver = Shadows.shadowOf(baseContext.contentResolver)
+        shadowResolver.registerInputStreamSupplier(uri) {
+            throw IOException("Mocked open error")
+        }
+        val service = PlaylistService()
+
+        val results = service.readPlaylist(baseContext, uri)
+
+        assertTrue(results.isEmpty())
+    }
+
+    @Test
     fun readPlaylist_returnsEmptyOnSecurityException() {
         val baseContext = ApplicationProvider.getApplicationContext<Context>()
         val uri = Uri.parse("content://test/playlist.m3u")


### PR DESCRIPTION
🎯 **What:** The tested gap in `PlaylistService.readPlaylist` regarding `IOException` being caught while opening a stream is addressed.
📊 **Coverage:** The test covers the scenario where an `IOException` is thrown during `ContentResolver.openInputStream` operation.
✨ **Result:** Test coverage improved, ensuring that `readPlaylist` gracefully handles stream open failures and returns an empty list without crashing.

---
*PR created automatically by Jules for task [3341192241412496342](https://jules.google.com/task/3341192241412496342) started by @kimptoc*