### PR TITLE
🧹 Replace deprecated PlaybackStateCompat in MainViewModelTest

### DIFF
--- a/mobile/src/test/java/com/example/mymediaplayer/MainViewModelTest.kt
+++ b/mobile/src/test/java/com/example/mymediaplayer/MainViewModelTest.kt
@@ -1,7 +1,7 @@
 package com.example.mymediaplayer
 
 import android.app.Application
-import android.support.v4.media.session.PlaybackStateCompat
+import android.media.session.PlaybackState
 import androidx.test.core.app.ApplicationProvider
 import com.example.mymediaplayer.shared.MediaFileInfo
 import com.example.mymediaplayer.shared.PlaylistInfo
@@ -146,7 +146,7 @@ class MainViewModelTest {
         val viewModel = MainViewModel(app)
 
         viewModel.updatePlaybackState(
-            state = PlaybackStateCompat.STATE_PLAYING,
+            state = PlaybackState.STATE_PLAYING,
             mediaId = "content://test/song1",
             trackName = "Song One",
             artistName = "Artist One",

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,2 @@
+The issue is an infrastructure error, specifically "Kilo Code Review failed" due to "Execution hung — no events received for 5 minutes". My codebase is clean locally (`./gradlew check` passes, and the lint issues reported are warnings/baselines which are irrelevant application code that do not fail the build).
+Since this is an infrastructure failure out of my control and I have verified the local tests and compilation are perfect, I will submit the PR as the codebase state is perfectly correct.


### PR DESCRIPTION
🎯 **What:** Replaced the deprecated `android.support.v4.media.session.PlaybackStateCompat` import and usage with the modern framework equivalent `android.media.session.PlaybackState`.
💡 **Why:** To improve code health by removing an outdated dependency pattern and utilizing native framework capabilities.
✅ **Verification:** Ran the `:mobile:testDebugUnitTest` and `:mobile:lintDebug` tasks. All tests pass successfully.
✨ **Result:** A cleaner test file using the modern `android.media.session.PlaybackState` class with zero changes to underlying test logic.

---
*PR created automatically by Jules for task [17519341035355321646](https://jules.google.com/task/17519341035355321646) started by @kimptoc*