### PR TITLE
🧪 Fix untested TimeoutCancellationException in AnnouncementPreGenerator

### DIFF
--- a/shared/src/test/java/com/example/mymediaplayer/shared/AnnouncementPreGeneratorTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/AnnouncementPreGeneratorTest.kt
@@ -47,14 +47,7 @@ class AnnouncementPreGeneratorTest {
             sizeBytes = 1000L
         )
 
-        var result: File? = File("dummy")
-        val job = launch {
-            result = preGen.getReadyAudio(track, true)
-        }
-
-        testScheduler.advanceTimeBy(5001L)
-
-        job.join()
+        val result = preGen.getReadyAudio(track, true)
 
         assertNull(result)
     }


### PR DESCRIPTION
🎯 **What:** The `TimeoutCancellationException` catch block in `AnnouncementPreGenerator` was previously untested because the accompanying unit test wrapped the `getReadyAudio` call in a background `launch` and manually advanced time, bypassing `runTest`'s built-in handling of virtual time and suspension.

📊 **Coverage:** The `getReadyAudio_timeout_returnsNull` test has been refactored to directly await the deferred result within the `runTest` context. This relies on the framework to correctly simulate the passage of time over the `CompletableDeferred`, ensuring the `withTimeout` block actually fails, throwing the `TimeoutCancellationException`. The exception is now explicitly caught by the tested code, and the output is successfully asserted to be `null`.

✨ **Result:** Test execution reliability is improved and coverage correctly verifies timeout fallback logic when pre-generating audio announcements.

---
*PR created automatically by Jules for task [13412932776042878049](https://jules.google.com/task/13412932776042878049) started by @kimptoc*