### PR TITLE
🧪 [testing improvement] Add missing IOException test for overwritePlaylist

### DIFF
--- a/shared/src/test/java/com/example/mymediaplayer/shared/PlaylistServiceErrorTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/PlaylistServiceErrorTest.kt
@@ -7,6 +7,7 @@ import android.content.pm.ProviderInfo
 import android.database.Cursor
 import android.net.Uri
 import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -95,6 +96,24 @@ class PlaylistServiceErrorTest {
 
         val result = service.writePlaylistWithName(baseContext, treeUri, files, "test_playlist")
         assertNull(result)
+    }
+
+    @Test
+    fun overwritePlaylist_returnsFalseOnIOException() {
+        val baseContext = ApplicationProvider.getApplicationContext<Context>()
+
+        val playlistUri = Uri.parse("content://myauth_valid/document/existing_file")
+
+        val shadowResolver = Shadows.shadowOf(baseContext.contentResolver)
+        shadowResolver.registerOutputStreamSupplier(playlistUri) {
+            throw IOException("Mocked exception")
+        }
+
+        val service = PlaylistService()
+        val files = listOf(MediaFileInfo("content://test/song1", "Song One", 1L, "Song One"))
+
+        val result = service.overwritePlaylist(baseContext, playlistUri, files)
+        assertFalse(result)
     }
 
 }


### PR DESCRIPTION
🎯 **What:** Added a missing test case in `PlaylistServiceErrorTest.kt` to cover the `IOException` block in the `overwritePlaylist` method.
📊 **Coverage:** The test mocks `Context.contentResolver.openOutputStream` to throw an `IOException` using Robolectric's `Shadows.shadowOf(baseContext.contentResolver).registerOutputStreamSupplier`, ensuring the service handles the exception gracefully by returning `false`.
✨ **Result:** Improved test coverage for `PlaylistService`, ensuring I/O errors during playlist overwrite are properly handled and verified.

---
*PR created automatically by Jules for task [11752384705608889643](https://jules.google.com/task/11752384705608889643) started by @kimptoc*