### PR TITLE
🧪 [Testing Improvement] Test exception handling in MediaMetadataHelper.release()

### DIFF
--- a/shared/src/test/java/com/example/mymediaplayer/shared/MediaMetadataHelperTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/MediaMetadataHelperTest.kt
@@ -11,8 +11,40 @@ import org.robolectric.Shadows.shadowOf
 import org.robolectric.shadows.ShadowMediaMetadataRetriever
 import org.robolectric.shadows.util.DataSource
 
+import android.media.MediaMetadataRetriever
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.Implementation
+import org.robolectric.annotation.Implements
+
+@Implements(MediaMetadataRetriever::class)
+class ShadowMediaMetadataRetrieverThrowingRelease : ShadowMediaMetadataRetriever() {
+    companion object {
+        var releaseCalled = false
+    }
+
+    @Implementation
+    fun release() {
+        releaseCalled = true
+        throw RuntimeException("Simulated release exception")
+    }
+}
+
 @RunWith(RobolectricTestRunner::class)
 class MediaMetadataHelperTest {
+
+    @Test
+    @Config(shadows = [ShadowMediaMetadataRetrieverThrowingRelease::class])
+    fun extractMetadata_whenReleaseThrowsException_isCaughtAndDoesNotCrash() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val uriString = "content://something/valid"
+        ShadowMediaMetadataRetrieverThrowingRelease.releaseCalled = false
+
+        // This will call extractMetadata, which will create MediaMetadataRetriever and eventually call release()
+        MediaMetadataHelper.extractMetadata(context, uriString)
+
+        // Verify that the mocked release function was actually called
+        org.junit.Assert.assertTrue("release() should have been called", ShadowMediaMetadataRetrieverThrowingRelease.releaseCalled)
+    }
 
     @Test
     fun extractMetadata_withInvalidUri_returnsEmptyMediaMetadataInfo() {


### PR DESCRIPTION
🎯 **What:**
Added a test to cover the `finally` block in `MediaMetadataHelper.extractMetadata` where `retriever.release()` is called. Simulated a `RuntimeException` using a custom Robolectric shadow `ShadowMediaMetadataRetrieverThrowingRelease` to ensure the exception is caught and does not crash the application.

📊 **Coverage:**
The scenario where releasing the `MediaMetadataRetriever` fails is now covered. This tests the inner `try-catch` block inside the `finally` block of `extractMetadata`.

✨ **Result:**
Improved test coverage and reliability for `MediaMetadataHelper.kt`, ensuring that the app gracefully handles failures during resource cleanup.

---
*PR created automatically by Jules for task [9079816106603064658](https://jules.google.com/task/9079816106603064658) started by @kimptoc*