### PR TITLE
🧹 [code health improvement] Refactor grouping logic in MainScreen

### DIFF
--- a/mobile/src/main/java/com/example/mymediaplayer/MainScreen.kt
+++ b/mobile/src/main/java/com/example/mymediaplayer/MainScreen.kt
@@ -1486,20 +1486,19 @@ private fun CategorySongsSection(
     }
 }
 
+private inline fun buildCounts(
+    files: List<MediaFileInfo>,
+    crossinline selector: (MediaFileInfo) -> String
+): Map<String, Int> = files.groupingBy(selector).eachCount()
+
 private fun buildAlbumCounts(files: List<MediaFileInfo>): Map<String, Int> =
-    files.groupingBy { file ->
-        file.album?.ifBlank { null } ?: "Unknown Album"
-    }.eachCount()
+    buildCounts(files) { it.album?.ifBlank { null } ?: "Unknown Album" }
 
 private fun buildArtistCounts(files: List<MediaFileInfo>): Map<String, Int> =
-    files.groupingBy { file ->
-        file.artist?.ifBlank { null } ?: "Unknown Artist"
-    }.eachCount()
+    buildCounts(files) { it.artist?.ifBlank { null } ?: "Unknown Artist" }
 
 private fun buildGenreCounts(files: List<MediaFileInfo>): Map<String, Int> =
-    files.groupingBy { file ->
-        bucketGenre(file.genre)
-    }.eachCount()
+    buildCounts(files) { bucketGenre(it.genre) }
 
 private fun decadeLabelForYear(year: Int?): String {
     if (year == null || year <= 0) return "Unknown Decade"


### PR DESCRIPTION
🎯 **What:** Extracted duplicated grouping logic in `build[Type]Counts` into a single generic `buildCounts` helper function.
💡 **Why:** Reduces duplicate code blocks, improving overall readability and code health. Using a generic `inline` function with `crossinline` is efficient in Kotlin.
✅ **Verification:** Passed all mobile test suites and linting successfully.
✨ **Result:** Simplified `MainScreen.kt` by consolidating duplicate grouping/eachCount blocks.

---
*PR created automatically by Jules for task [9820841899482828808](https://jules.google.com/task/9820841899482828808) started by @kimptoc*