### PR TITLE
🔒 [security fix] Validate intent data in MyMusicService

### DIFF
--- a/shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
@@ -659,8 +659,31 @@ class MyMusicService : MediaBrowserServiceCompat() {
             return START_NOT_STICKY
         }
         if (intent?.action == ACTION_MEDIA_PLAY_FROM_SEARCH) {
-            val query = intent.getStringExtra(SearchManager.QUERY)
-            val extras = intent.extras?.let { Bundle(it) }
+            val rawQuery = intent.getStringExtra(SearchManager.QUERY)
+            val query = if (rawQuery != null && rawQuery.length > 500) {
+                rawQuery.substring(0, 500)
+            } else {
+                rawQuery
+            }
+
+            val extras = intent.extras?.let { originalExtras ->
+                Bundle().apply {
+                    val allowedKeys = setOf(
+                        "android.intent.extra.focus",
+                        "android.intent.extra.artist",
+                        "android.intent.extra.album",
+                        "android.intent.extra.genre",
+                        "android.intent.extra.title",
+                        "android.intent.extra.playlist"
+                    )
+                    for (key in allowedKeys) {
+                        val value = originalExtras.getString(key)
+                        if (value != null) {
+                            putString(key, if (value.length > 500) value.substring(0, 500) else value)
+                        }
+                    }
+                }
+            }
             playJob?.cancel()
             playJob = serviceScope.launch {
                 playMutex.withLock {

--- a/shared/src/test/java/com/example/mymediaplayer/shared/SecurityTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/SecurityTest.kt
@@ -1,0 +1,38 @@
+package com.example.mymediaplayer.shared
+
+import android.os.Bundle
+import org.junit.Test
+import org.junit.Assert.*
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class SecurityTest {
+
+    @Test
+    fun testBundle() {
+        val bundle = Bundle()
+        bundle.putString("android.intent.extra.focus", "123")
+        bundle.putString("unknown", "456")
+
+        val allowedKeys = setOf(
+            "android.intent.extra.focus",
+            "android.intent.extra.artist",
+            "android.intent.extra.album",
+            "android.intent.extra.genre",
+            "android.intent.extra.title",
+            "android.intent.extra.playlist"
+        )
+
+        val safeExtras = Bundle()
+        for (key in allowedKeys) {
+            val value = bundle.getString(key)
+            if (value != null && value.length <= 1000) {
+                safeExtras.putString(key, value)
+            }
+        }
+
+        assertEquals("123", safeExtras.getString("android.intent.extra.focus"))
+        assertNull(safeExtras.getString("unknown"))
+    }
+}


### PR DESCRIPTION
🎯 **What:**
The vulnerability was fixed by validating and limiting the length of intent `query` string and selectively extracting only the required `extras` for `ACTION_MEDIA_PLAY_FROM_SEARCH`.

⚠️ **Risk:**
Untrusted apps calling this exported service could inject overly large query strings or unknown, memory-consuming items in the `extras` bundle, potentially causing a crash due to memory exhaustion (OOM), intent spoofing, or denial of service.

🛡️ **Solution:**
Truncated the `query` length to 500 characters and explicitly parsed only expected keys from the `extras` bundle via an allow-list, while limiting string lengths there too.

---
*PR created automatically by Jules for task [10468527474723224523](https://jules.google.com/task/10468527474723224523) started by @kimptoc*