### PR TITLE
🧪 [testing improvement] Add missing SecurityException handling test in overwritePlaylist

### DIFF
--- a/shared/src/test/java/com/example/mymediaplayer/shared/PlaylistServiceErrorTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/PlaylistServiceErrorTest.kt
@@ -97,4 +97,20 @@ class PlaylistServiceErrorTest {
         assertNull(result)
     }
 
+    @Test
+    fun overwritePlaylist_returnsFalseOnSecurityException() {
+        val baseContext = ApplicationProvider.getApplicationContext<Context>()
+        val shadowResolver = Shadows.shadowOf(baseContext.contentResolver)
+        val targetUri = Uri.parse("content://myauth_valid/document/new_file")
+
+        shadowResolver.registerOutputStreamSupplier(targetUri) {
+            throw SecurityException("Mocked exception")
+        }
+
+        val service = PlaylistService()
+        val files = listOf(MediaFileInfo("content://test/song1", "Song One", 1L, "Song One"))
+
+        val result = service.overwritePlaylist(baseContext, targetUri, files)
+        org.junit.Assert.assertFalse(result)
+    }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed (missing SecurityException handling test in overwritePlaylist).
📊 **Coverage:** What scenarios are now tested (SecurityException thrown during output stream opening).
✨ **Result:** The improvement in test coverage.

---
*PR created automatically by Jules for task [6309441146691087245](https://jules.google.com/task/6309441146691087245) started by @kimptoc*