### PR TITLE
🔒 [security fix] Prevent Bluetooth autoplay from unbonded devices

### DIFF
--- a/mobile/src/main/java/com/example/mymediaplayer/BluetoothAutoPlayReceiver.kt
+++ b/mobile/src/main/java/com/example/mymediaplayer/BluetoothAutoPlayReceiver.kt
@@ -58,6 +58,13 @@ class BluetoothAutoPlayReceiver : BroadcastReceiver() {
         val allowlist = trustedAddresses(prefs)
         @Suppress("MissingPermission")
         val name = runCatching { device.name }.getOrNull()
+
+        @Suppress("MissingPermission")
+        if (runCatching { device.bondState }.getOrNull() != BluetoothDevice.BOND_BONDED) {
+            record(prefs, "unbonded_device", address, name)
+            return
+        }
+
         if (address !in allowlist) {
             record(prefs, "untrusted_device", address, name)
             return

--- a/mobile/src/test/java/com/example/mymediaplayer/BluetoothAutoPlayReceiverTest.kt
+++ b/mobile/src/test/java/com/example/mymediaplayer/BluetoothAutoPlayReceiverTest.kt
@@ -44,14 +44,30 @@ class BluetoothAutoPlayReceiverTest {
             .apply()
     }
 
-    private fun createConnectedIntent(): Intent {
+    private fun createConnectedIntent(isBonded: Boolean = true): Intent {
         @Suppress("DEPRECATION")
         val adapter = BluetoothAdapter.getDefaultAdapter()
         val bluetoothDevice = adapter.getRemoteDevice(testAddress)
 
+        if (isBonded) {
+            shadowOf(adapter).setBondedDevices(setOf(bluetoothDevice))
+            // Robolectric BluetoothDevice shadow doesn't automatically update bond state when set in adapter
+            shadowOf(bluetoothDevice).setBondState(BluetoothDevice.BOND_BONDED)
+        } else {
+            shadowOf(bluetoothDevice).setBondState(BluetoothDevice.BOND_NONE)
+        }
+
         return Intent(BluetoothDevice.ACTION_ACL_CONNECTED).apply {
             putExtra(BluetoothDevice.EXTRA_DEVICE, bluetoothDevice)
         }
+    }
+
+    @Test
+    fun `when connection happens with unbonded device, it is rejected`() {
+        val intent = createConnectedIntent(isBonded = false)
+        receiver.onReceive(context, intent)
+
+        assertEquals("unbonded_device", prefs.getString("bt_last_reason", null))
     }
 
     @Test


### PR DESCRIPTION
🎯 **What:** The `BluetoothAutoPlayReceiver` insecurely implicitly trusted Bluetooth MAC addresses for autoplay functionality, allowing unbonded devices with spoofed MAC addresses to trigger playback.
⚠️ **Risk:** An attacker could spoof a trusted MAC address and potentially launch the app or play media without pairing, which constitutes a security vulnerability via device impersonation.
🛡️ **Solution:** Added a check to enforce that the device's `bondState` must be `BluetoothDevice.BOND_BONDED`. Unpaired devices are rejected with an 'unbonded_device' log, regardless of their MAC address. Updated tests correctly mock the device bond state to verify this behavior.

---
*PR created automatically by Jules for task [5433884096542494810](https://jules.google.com/task/5433884096542494810) started by @kimptoc*