### PR TITLE
⚡ [performance improvement N+1 Genre Members Query optimization]

### DIFF
--- a/shared/src/main/java/com/example/mymediaplayer/shared/MediaCacheService.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/MediaCacheService.kt
@@ -230,18 +230,19 @@ class MediaCacheService {
         audioIds: Set<Long>,
         allGenresByAudioId: MutableMap<Long, MutableList<String>>
     ) {
+        if (audioIds.isEmpty()) return
         val membersUri = MediaStore.Audio.Genres.Members.getContentUri("external", genreId)
+        val selection = "${MediaStore.Audio.Genres.Members.AUDIO_ID} IN (${audioIds.joinToString(",")})"
         resolver.query(
             membersUri,
             arrayOf(MediaStore.Audio.Genres.Members.AUDIO_ID),
-            null,
+            selection,
             null,
             null
         )?.use { membersCursor ->
             val audioIdIndex = membersCursor.getColumnIndexOrThrow(MediaStore.Audio.Genres.Members.AUDIO_ID)
             while (membersCursor.moveToNext()) {
                 val audioId = membersCursor.getLong(audioIdIndex)
-                if (audioId !in audioIds) continue
                 allGenresByAudioId.getOrPut(audioId) { mutableListOf() }.add(genreName)
             }
         }


### PR DESCRIPTION
💡 **What:** Optimized `collectGenreMembers` to push filtering down to the database via a single literal `IN` clause instead of fetching all members for every genre and filtering in memory.
🎯 **Why:** The previous code fetched every single member for every genre into memory. By passing the relevant `audioIds` via an `IN` clause directly, the database returns only the needed rows, drastically reducing cursor size and iteration time, while maintaining exactly one query per genre to avoid multiplying IPC transactions.
📊 **Measured Improvement:** Replaces a full dataset load per genre with a targeted query, preventing massive cursor windows and OOM scenarios without multiplying database queries or hitting SQLite variable limits.

---
*PR created automatically by Jules for task [1386191623048157867](https://jules.google.com/task/1386191623048157867) started by @kimptoc*