### PR TITLE
Ignore .qwen/ local config directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@
 local.properties
 /shared/build
 temp
+.qwen/


### PR DESCRIPTION
Adds `.qwen/` to .gitignore to prevent local Qwen Code config from being tracked.