### PR TITLE
🧹 Remove unused import in MediaCacheServiceTest

### DIFF
--- a/shared/src/test/java/com/example/mymediaplayer/shared/MediaCacheServiceTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/MediaCacheServiceTest.kt
@@ -1,7 +1,6 @@
 package com.example.mymediaplayer.shared
 
 import android.content.Context
-import android.net.Uri
 import android.provider.DocumentsContract
 import androidx.test.core.app.ApplicationProvider
 import kotlinx.coroutines.Dispatchers


### PR DESCRIPTION
🎯 **What:** Removed unused `android.net.Uri` import from `MediaCacheServiceTest.kt`.
💡 **Why:** Removing unused imports is safe, trivial, and improves code hygiene.
✅ **Verification:** Verified by running the test suite via `./gradlew test`.
✨ **Result:** A cleaner codebase with no unused imports in the test class.

---
*PR created automatically by Jules for task [1694959618121122667](https://jules.google.com/task/1694959618121122667) started by @kimptoc*