### PR TITLE
🧹 [code health] Remove unused URLStreamHandlerFactory import

### DIFF
--- a/shared/src/test/java/com/example/mymediaplayer/shared/NetworkQualityCheckerTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/NetworkQualityCheckerTest.kt
@@ -20,7 +20,6 @@ import java.net.HttpURLConnection
 import java.net.URL
 import java.net.URLConnection
 import java.net.URLStreamHandler
-import java.net.URLStreamHandlerFactory
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.ResponseBody.Companion.toResponseBody
 


### PR DESCRIPTION
🎯 **What:**
Removed the unused import `java.net.URLStreamHandlerFactory` from `shared/src/test/java/com/example/mymediaplayer/shared/NetworkQualityCheckerTest.kt`.

💡 **Why:**
Removing unused imports is a safe and trivial change that improves code hygiene, readability, and maintainability by keeping the file clean and reducing visual noise.

✅ **Verification:**
Confirmed that removing the import did not cause any build issues. Ran `./gradlew :shared:testDebugUnitTest --tests com.example.mymediaplayer.shared.NetworkQualityCheckerTest` and verified that the test passes successfully.

✨ **Result:**
The test file is now cleaner and free of the unused import, contributing to better overall code health.

---
*PR created automatically by Jules for task [3726733451368937862](https://jules.google.com/task/3726733451368937862) started by @kimptoc*