### PR TITLE
🧹 Remove unused runBlocking import in PlaylistService

### DIFF
--- a/shared/src/main/java/com/example/mymediaplayer/shared/PlaylistService.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/PlaylistService.kt
@@ -14,7 +14,6 @@ import java.util.Locale
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.runBlocking
 
 open class PlaylistService {
 


### PR DESCRIPTION
🎯 **What:** Removed the unused `import kotlinx.coroutines.runBlocking` from `shared/src/main/java/com/example/mymediaplayer/shared/PlaylistService.kt`.
💡 **Why:** Removing unused imports improves code readability and hygiene by keeping the file free of dead code and unneeded dependencies.
✅ **Verification:** Verified by running the test suite (`./gradlew test`) to ensure functionality and compilation are completely unaffected.
✨ **Result:** The unused import has been successfully removed, resulting in cleaner code without any functional regressions.

---
*PR created automatically by Jules for task [5142635615033288432](https://jules.google.com/task/5142635615033288432) started by @kimptoc*