### PR TITLE
🧹 [code health] Remove unused Network import in NetworkQualityCheckerTest

### DIFF
--- a/shared/src/test/java/com/example/mymediaplayer/shared/NetworkQualityCheckerTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/NetworkQualityCheckerTest.kt
@@ -2,7 +2,6 @@ package com.example.mymediaplayer.shared
 
 import android.content.Context
 import android.net.ConnectivityManager
-import android.net.Network
 import android.net.NetworkCapabilities
 import androidx.test.core.app.ApplicationProvider
 import kotlinx.coroutines.runBlocking


### PR DESCRIPTION
🎯 **What:** Removed unused `android.net.Network` import from `NetworkQualityCheckerTest.kt`.
💡 **Why:** Clean up unused imports to improve code hygiene.
✅ **Verification:** Ran test `NetworkQualityCheckerTest` and they passed.
✨ **Result:** Cleaner code without unused imports.

---
*PR created automatically by Jules for task [17049509921309041026](https://jules.google.com/task/17049509921309041026) started by @kimptoc*