### PR TITLE
🧹 [Code Health] Remove unused import in MediaMetadataHelperTest

### DIFF
--- a/shared/src/test/java/com/example/mymediaplayer/shared/MediaMetadataHelperTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/MediaMetadataHelperTest.kt
@@ -7,7 +7,6 @@ import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.Shadows.shadowOf
 import org.robolectric.shadows.ShadowMediaMetadataRetriever
 import org.robolectric.shadows.util.DataSource
 


### PR DESCRIPTION
🎯 **What:** Removed unused `org.robolectric.Shadows.shadowOf` import from `MediaMetadataHelperTest.kt`.
💡 **Why:** Removing unused imports improves code hygiene, readability, and reduces unnecessary clutter.
✅ **Verification:** Ran `./gradlew :shared:testDebugUnitTest --tests "*MediaMetadataHelperTest*"` to verify all tests still pass and no compilation errors were introduced.
✨ **Result:** Cleaner code and better code health.

---
*PR created automatically by Jules for task [13509795549029855763](https://jules.google.com/task/13509795549029855763) started by @kimptoc*