### PR TITLE
🧹 [Code Health] Refactor SettingsScreen to reduce complexity

### DIFF
--- a/mobile/src/main/java/com/example/mymediaplayer/SettingsScreen.kt
+++ b/mobile/src/main/java/com/example/mymediaplayer/SettingsScreen.kt
@@ -64,52 +64,25 @@ fun SettingsScreen(
     BackHandler { onBack() }
 
     Scaffold(
-        topBar = {
-            TopAppBar(
-                title = { Text("Settings") },
-                navigationIcon = {
-                    IconButton(onClick = onBack) {
-                        Text("\u2190", style = MaterialTheme.typography.titleLarge)
-                    }
-                }
-            )
-        }
+        topBar = { SettingsTopAppBar(onBack = onBack) }
     ) { padding ->
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(padding)
-                .verticalScroll(rememberScrollState())
-                .padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(4.dp)
-        ) {
-            VoiceAnnouncementsSection(
-                trackVoiceIntroEnabled = trackVoiceIntroEnabled,
-                trackVoiceOutroEnabled = trackVoiceOutroEnabled,
-                onToggleTrackVoiceIntro = onToggleTrackVoiceIntro,
-                onToggleTrackVoiceOutro = onToggleTrackVoiceOutro,
-                onShowCloudAnnouncementSettingsDialog = { showCloudAnnouncementSettingsDialog = true }
-            )
-
-            Spacer(modifier = Modifier.height(16.dp))
-
-            BluetoothSection(
-                bluetoothAutoPlayEnabled = bluetoothAutoPlayEnabled,
-                onToggleBluetoothAutoPlay = onToggleBluetoothAutoPlay,
-                onAddCurrentBluetoothDevice = onAddCurrentBluetoothDevice,
-                onShowManageTrustedBluetoothDialog = { showManageTrustedBluetoothDialog = true },
-                onShowBluetoothDiagnosticsDialog = {
-                    onRefreshBluetoothDiagnostics()
-                    showBluetoothDiagnosticsDialog = true
-                }
-            )
-
-            Spacer(modifier = Modifier.height(16.dp))
-
-            StorageSection(
-                onChoosePlaylistSaveFolder = onChoosePlaylistSaveFolder
-            )
-        }
+        SettingsScreenContent(
+            padding = padding,
+            trackVoiceIntroEnabled = trackVoiceIntroEnabled,
+            trackVoiceOutroEnabled = trackVoiceOutroEnabled,
+            onToggleTrackVoiceIntro = onToggleTrackVoiceIntro,
+            onToggleTrackVoiceOutro = onToggleTrackVoiceOutro,
+            onShowCloudAnnouncementSettingsDialog = { showCloudAnnouncementSettingsDialog = true },
+            bluetoothAutoPlayEnabled = bluetoothAutoPlayEnabled,
+            onToggleBluetoothAutoPlay = onToggleBluetoothAutoPlay,
+            onAddCurrentBluetoothDevice = onAddCurrentBluetoothDevice,
+            onShowManageTrustedBluetoothDialog = { showManageTrustedBluetoothDialog = true },
+            onShowBluetoothDiagnosticsDialog = {
+                onRefreshBluetoothDiagnostics()
+                showBluetoothDiagnosticsDialog = true
+            },
+            onChoosePlaylistSaveFolder = onChoosePlaylistSaveFolder
+        )
     }
 
     if (showCloudAnnouncementSettingsDialog) {
@@ -429,4 +402,66 @@ internal fun BluetoothDiagnosticsDialog(
             }
         }
     )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SettingsTopAppBar(onBack: () -> Unit) {
+    TopAppBar(
+        title = { Text("Settings") },
+        navigationIcon = {
+            IconButton(onClick = onBack) {
+                Text("\u2190", style = MaterialTheme.typography.titleLarge)
+            }
+        }
+    )
+}
+
+@Composable
+private fun SettingsScreenContent(
+    padding: androidx.compose.foundation.layout.PaddingValues,
+    trackVoiceIntroEnabled: Boolean,
+    trackVoiceOutroEnabled: Boolean,
+    onToggleTrackVoiceIntro: () -> Unit,
+    onToggleTrackVoiceOutro: () -> Unit,
+    onShowCloudAnnouncementSettingsDialog: () -> Unit,
+    bluetoothAutoPlayEnabled: Boolean,
+    onToggleBluetoothAutoPlay: () -> Unit,
+    onAddCurrentBluetoothDevice: () -> Unit,
+    onShowManageTrustedBluetoothDialog: () -> Unit,
+    onShowBluetoothDiagnosticsDialog: () -> Unit,
+    onChoosePlaylistSaveFolder: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(padding)
+            .verticalScroll(rememberScrollState())
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        VoiceAnnouncementsSection(
+            trackVoiceIntroEnabled = trackVoiceIntroEnabled,
+            trackVoiceOutroEnabled = trackVoiceOutroEnabled,
+            onToggleTrackVoiceIntro = onToggleTrackVoiceIntro,
+            onToggleTrackVoiceOutro = onToggleTrackVoiceOutro,
+            onShowCloudAnnouncementSettingsDialog = onShowCloudAnnouncementSettingsDialog
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        BluetoothSection(
+            bluetoothAutoPlayEnabled = bluetoothAutoPlayEnabled,
+            onToggleBluetoothAutoPlay = onToggleBluetoothAutoPlay,
+            onAddCurrentBluetoothDevice = onAddCurrentBluetoothDevice,
+            onShowManageTrustedBluetoothDialog = onShowManageTrustedBluetoothDialog,
+            onShowBluetoothDiagnosticsDialog = onShowBluetoothDiagnosticsDialog
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        StorageSection(
+            onChoosePlaylistSaveFolder = onChoosePlaylistSaveFolder
+        )
+    }
 }


### PR DESCRIPTION
🎯 **What:** Extracted `SettingsTopAppBar` and `SettingsScreenContent` out of the large `SettingsScreen` composable function.
💡 **Why:** The `SettingsScreen` function was exceeding 100 lines. Breaking it down improves the readability and maintainability of the codebase.
✅ **Verification:** Rebuilt and ran the full unit test suite to ensure no existing functionality was broken.
✨ **Result:** A more modular and simpler `SettingsScreen` code structure.

---
*PR created automatically by Jules for task [5348032158747253971](https://jules.google.com/task/5348032158747253971) started by @kimptoc*