### PR TITLE
🧹 [code health] Break down overly complex PlaylistsSection composable

### DIFF
--- a/mobile/src/main/java/com/example/mymediaplayer/MainScreen.kt
+++ b/mobile/src/main/java/com/example/mymediaplayer/MainScreen.kt
@@ -551,7 +551,6 @@ fun MainScreen(
                         onSavePlaylistEdits = onSavePlaylistEdits,
                         onPlayPlaylist = onPlayPlaylist,
                         onShufflePlaylistSongs = onShufflePlaylistSongs,
-                        onPlaySongs = onPlaySongs,
                         onStop = onStop,
                         onNext = onNext,
                         onPrev = onPrev,
@@ -1732,7 +1731,6 @@ private fun PlaylistsSection(
     onSavePlaylistEdits: (PlaylistInfo, List<MediaFileInfo>) -> Unit,
     onPlayPlaylist: (PlaylistInfo) -> Unit,
     onShufflePlaylistSongs: (PlaylistInfo, List<MediaFileInfo>) -> Unit,
-    onPlaySongs: (List<MediaFileInfo>) -> Unit,
     onStop: () -> Unit,
     onNext: () -> Unit,
     onPrev: () -> Unit,
@@ -1742,16 +1740,105 @@ private fun PlaylistsSection(
     onToggleFavorite: (MediaFileInfo) -> Unit,
     currentMediaId: String?
 ) {
-    var isEditing by remember(selectedPlaylist?.uriString) { mutableStateOf(false) }
-    var editableSongs by remember(selectedPlaylist?.uriString) { mutableStateOf<List<MediaFileInfo>>(emptyList()) }
-    var draggingIndex by remember(selectedPlaylist?.uriString) { mutableStateOf<Int?>(null) }
-    var draggingOffsetY by remember(selectedPlaylist?.uriString) { mutableFloatStateOf(0f) }
-    var dedupeOnSave by remember(selectedPlaylist?.uriString) { mutableStateOf(false) }
-    var editSearchQuery by remember(selectedPlaylist?.uriString) { mutableStateOf("") }
-    var showDiscardChangesDialog by remember(selectedPlaylist?.uriString) { mutableStateOf(false) }
-    var pendingClearSelection by remember(selectedPlaylist?.uriString) { mutableStateOf(false) }
+    if (playlists.isEmpty()) {
+        Text("No playlists found")
+        return
+    }
+
+    if (selectedPlaylist == null) {
+        PlaylistList(
+            playlists = playlists,
+            onRequestRenamePlaylist = onRequestRenamePlaylist,
+            onRequestDeletePlaylist = onRequestDeletePlaylist,
+            onPlaylistSelected = onPlaylistSelected
+        )
+    } else {
+        PlaylistDetails(
+            selectedPlaylist = selectedPlaylist,
+            playlistSongs = playlistSongs,
+            isLoading = isLoading,
+            isPlaying = isPlaying,
+            isPlayingPlaylist = isPlayingPlaylist,
+            queueTitle = queueTitle,
+            hasNext = hasNext,
+            hasPrev = hasPrev,
+            onClearPlaylistSelection = onClearPlaylistSelection,
+            onSavePlaylistEdits = onSavePlaylistEdits,
+            onPlayPlaylist = onPlayPlaylist,
+            onShufflePlaylistSongs = onShufflePlaylistSongs,
+            onStop = onStop,
+            onNext = onNext,
+            onPrev = onPrev,
+            onFileClick = onFileClick,
+            onAddToPlaylist = onAddToPlaylist,
+            favoriteUris = favoriteUris,
+            onToggleFavorite = onToggleFavorite,
+            currentMediaId = currentMediaId
+        )
+    }
+}
+
+@Composable
+private fun PlaylistList(
+    playlists: List<PlaylistInfo>,
+    onRequestRenamePlaylist: (PlaylistInfo) -> Unit,
+    onRequestDeletePlaylist: (PlaylistInfo) -> Unit,
+    onPlaylistSelected: (PlaylistInfo) -> Unit
+) {
+    Surface(
+        color = MaterialTheme.colorScheme.secondaryContainer,
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        LazyColumn(modifier = Modifier.padding(8.dp)) {
+            items(playlists) { playlist ->
+                val isSmart = playlist.uriString.startsWith(MainViewModel.SMART_PREFIX)
+                PlaylistCard(
+                    playlist = playlist,
+                    isCompact = false,
+                    isSmart = isSmart,
+                    onRename = { if (!isSmart) onRequestRenamePlaylist(playlist) },
+                    onDelete = { if (!isSmart) onRequestDeletePlaylist(playlist) },
+                    onClick = { onPlaylistSelected(playlist) }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun PlaylistDetails(
+    selectedPlaylist: PlaylistInfo,
+    playlistSongs: List<MediaFileInfo>,
+    isLoading: Boolean,
+    isPlaying: Boolean,
+    isPlayingPlaylist: Boolean,
+    queueTitle: String?,
+    hasNext: Boolean,
+    hasPrev: Boolean,
+    onClearPlaylistSelection: () -> Unit,
+    onSavePlaylistEdits: (PlaylistInfo, List<MediaFileInfo>) -> Unit,
+    onPlayPlaylist: (PlaylistInfo) -> Unit,
+    onShufflePlaylistSongs: (PlaylistInfo, List<MediaFileInfo>) -> Unit,
+    onStop: () -> Unit,
+    onNext: () -> Unit,
+    onPrev: () -> Unit,
+    onFileClick: (MediaFileInfo) -> Unit,
+    onAddToPlaylist: (MediaFileInfo) -> Unit,
+    favoriteUris: Set<String>,
+    onToggleFavorite: (MediaFileInfo) -> Unit,
+    currentMediaId: String?
+) {
+    var isEditing by remember(selectedPlaylist.uriString) { mutableStateOf(false) }
+    var editableSongs by remember(selectedPlaylist.uriString) { mutableStateOf<List<MediaFileInfo>>(emptyList()) }
+    var draggingIndex by remember(selectedPlaylist.uriString) { mutableStateOf<Int?>(null) }
+    var draggingOffsetY by remember(selectedPlaylist.uriString) { mutableFloatStateOf(0f) }
+    var dedupeOnSave by remember(selectedPlaylist.uriString) { mutableStateOf(false) }
+    var editSearchQuery by remember(selectedPlaylist.uriString) { mutableStateOf("") }
+    var showDiscardChangesDialog by remember(selectedPlaylist.uriString) { mutableStateOf(false) }
+    var pendingClearSelection by remember(selectedPlaylist.uriString) { mutableStateOf(false) }
     val dragSwapThresholdPx = with(androidx.compose.ui.platform.LocalDensity.current) { 56.dp.toPx() }
-    LaunchedEffect(selectedPlaylist?.uriString, playlistSongs, isEditing) {
+
+    LaunchedEffect(selectedPlaylist.uriString, playlistSongs, isEditing) {
         if (!isEditing) {
             editableSongs = playlistSongs
             dedupeOnSave = false
@@ -1760,37 +1847,12 @@ private fun PlaylistsSection(
     }
     val hasUnsavedChanges = isEditing && (editableSongs != playlistSongs || dedupeOnSave)
 
-    if (playlists.isEmpty()) {
-        Text("No playlists found")
-        return
-    }
-
-    if (selectedPlaylist == null) {
-        Surface(
-            color = MaterialTheme.colorScheme.secondaryContainer,
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            LazyColumn(modifier = Modifier.padding(8.dp)) {
-                items(playlists) { playlist ->
-                    val isSmart = playlist.uriString.startsWith(MainViewModel.SMART_PREFIX)
-                    PlaylistCard(
-                        playlist = playlist,
-                        isCompact = false,
-                        isSmart = isSmart,
-                        onRename = { if (!isSmart) onRequestRenamePlaylist(playlist) },
-                        onDelete = { if (!isSmart) onRequestDeletePlaylist(playlist) },
-                        onClick = { onPlaylistSelected(playlist) }
-                    )
-                }
-            }
-        }
-    } else {
-        Surface(
-            color = MaterialTheme.colorScheme.surfaceVariant,
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            Column(modifier = Modifier.padding(12.dp)) {
-                TextButton(
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Column(modifier = Modifier.padding(12.dp)) {
+            TextButton(
                 onClick = {
                     if (hasUnsavedChanges) {
                         pendingClearSelection = true
@@ -1901,6 +1963,7 @@ private fun PlaylistsSection(
                 }
                 Spacer(modifier = Modifier.height(8.dp))
             }
+
             if (displayedSongs.isEmpty()) {
                 Text("No songs in playlist")
             } else {
@@ -2023,7 +2086,6 @@ private fun PlaylistsSection(
                 }
             }
         }
-        }
     }
 
     if (showDiscardChangesDialog) {
@@ -2060,7 +2122,6 @@ private fun PlaylistsSection(
         )
     }
 }
-
 @Composable
 private fun PlaybackButtonsRow(
     isPlaying: Boolean,


### PR DESCRIPTION
🎯 **What:** Refactored the `PlaylistsSection` composable in `MainScreen.kt` by extracting its main view states into two separate, smaller composables: `PlaylistList` and `PlaylistDetails`. Removed the unused `onPlaySongs` parameter.
💡 **Why:** `PlaylistsSection` exceeded 100 lines and was overly complex, managing both the list view of all playlists and the editing state of a single selected playlist. This refactoring greatly improves the code's readability and long-term maintainability by separating these distinct concerns.
✅ **Verification:** Verified by running the test suite and lint checks using `./gradlew :mobile:lint :mobile:testDebugUnitTest`. The refactor accurately preserves all original states and interactions without introducing regressions.
✨ **Result:** A more modular and cleaner composable structure that is easier to maintain and strictly adheres to the Single Responsibility Principle.

---
*PR created automatically by Jules for task [15807699722561445227](https://jules.google.com/task/15807699722561445227) started by @kimptoc*