### PR TITLE
🧹 [Code Health] Simplify handlePlayAllOrShuffle function

### DIFF
--- a/shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
@@ -1978,12 +1978,8 @@ class MyMusicService : MediaBrowserServiceCompat() {
         }
     }
 
-    private suspend fun handlePlayAllOrShuffle(resolvedMediaId: String) {
-        val isShuffle = resolvedMediaId.startsWith(ACTION_SHUFFLE_PREFIX)
-        val listKey = resolvedMediaId.removePrefix(
-            if (isShuffle) ACTION_SHUFFLE_PREFIX else ACTION_PLAY_ALL_PREFIX
-        )
-        val tracks = when {
+    private suspend fun resolveTracksForListKey(listKey: String): List<MediaFileInfo> {
+        return when {
             listKey == SONGS_ID -> mediaCacheService.cachedFiles
             listKey == PLAYLISTS_ID -> {
                 val all = kotlinx.coroutines.coroutineScope {
@@ -2053,16 +2049,10 @@ class MyMusicService : MediaBrowserServiceCompat() {
             }
             else -> emptyList()
         }
+    }
 
-        if (tracks.isEmpty()) {
-            updatePlaybackState(PlaybackStateCompat.STATE_ERROR)
-            return
-        }
-
-        val ordered = if (isShuffle) tracks.shuffled() else tracks
-        playlistQueue = ordered
-        currentQueueIndex = 0
-        currentPlaylistName = when {
+    private fun resolvePlaylistNameForListKey(listKey: String): String {
+        return when {
             listKey == SONGS_ID -> "All Songs"
             listKey == PLAYLISTS_ID -> "All Playlists"
             listKey.startsWith(PLAYLIST_SHORT_PREFIX) -> {
@@ -2096,9 +2086,21 @@ class MyMusicService : MediaBrowserServiceCompat() {
             }
             else -> "Playlist"
         }
-        updateSessionQueue()
-        playTrack(playlistQueue[currentQueueIndex])
-        savePlaybackSnapshot()
+    }
+
+    private suspend fun handlePlayAllOrShuffle(resolvedMediaId: String) {
+        val isShuffle = resolvedMediaId.startsWith(ACTION_SHUFFLE_PREFIX)
+        val listKey = resolvedMediaId.removePrefix(
+            if (isShuffle) ACTION_SHUFFLE_PREFIX else ACTION_PLAY_ALL_PREFIX
+        )
+        val tracks = resolveTracksForListKey(listKey)
+
+        if (tracks.isEmpty()) {
+            updatePlaybackState(PlaybackStateCompat.STATE_ERROR)
+            return
+        }
+
+        playQueueAndSaveSnapshot(tracks, isShuffle, resolvePlaylistNameForListKey(listKey))
     }
 
     private suspend fun handlePlayPlaylist(resolvedMediaId: String) {


### PR DESCRIPTION
🎯 **What:** Extracted tracks resolving and playlist name resolving logic out of `handlePlayAllOrShuffle` into separate private functions `resolveTracksForListKey` and `resolvePlaylistNameForListKey`. Also utilized existing `playQueueAndSaveSnapshot` method to further simplify.
💡 **Why:** `handlePlayAllOrShuffle` function was too long and complex, breaking it down into focused helper functions significantly improves readability and maintainability.
✅ **Verification:** Validated that standard unit tests run successfully, ensuring logic remains correctly bounded.
✨ **Result:** Reduced the size and cyclomatic complexity of `handlePlayAllOrShuffle`.

---
*PR created automatically by Jules for task [15732605264292438549](https://jules.google.com/task/15732605264292438549) started by @kimptoc*