### PR TITLE
🧹 [Code Health] Remove unused assertEquals import in NetworkQualityBenchmarkTest

### DIFF
--- a/shared/src/test/java/com/example/mymediaplayer/shared/NetworkQualityBenchmarkTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/NetworkQualityBenchmarkTest.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.runBlocking
 import org.junit.After
-import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith


### PR DESCRIPTION
🎯 **What:** Removed the unused import `org.junit.Assert.assertEquals` from `shared/src/test/java/com/example/mymediaplayer/shared/NetworkQualityBenchmarkTest.kt`.

💡 **Why:** Unused imports clutter the codebase and can be confusing. Removing them improves code readability and maintainability without altering any behavior.

✅ **Verification:** Verified the fix by successfully running `./gradlew :shared:testDebugUnitTest --tests "*NetworkQualityBenchmarkTest*"`. The removal of the unused import does not impact the application or its tests.

✨ **Result:** A cleaner test file free from unnecessary imports.

---
*PR created automatically by Jules for task [14161536799052372492](https://jules.google.com/task/14161536799052372492) started by @kimptoc*