### PR TITLE
🧪 [add PlaylistService.readPlaylist error tests]

### DIFF
--- a/shared/src/test/java/com/example/mymediaplayer/shared/PlaylistServiceTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/PlaylistServiceTest.kt
@@ -3,6 +3,7 @@ package com.example.mymediaplayer.shared
 import android.content.Context
 import android.net.Uri
 import androidx.test.core.app.ApplicationProvider
+import java.io.FileNotFoundException
 import java.io.IOException
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -22,6 +23,55 @@ class PlaylistServiceTest {
         val shadowResolver = Shadows.shadowOf(baseContext.contentResolver)
         shadowResolver.registerInputStreamSupplier(uri) {
             throw SecurityException("nope")
+        }
+        val service = PlaylistService()
+
+        val results = service.readPlaylist(baseContext, uri)
+
+        assertTrue(results.isEmpty())
+    }
+
+    @Test
+    fun readPlaylist_returnsEmptyOnFileNotFoundException() {
+        val baseContext = ApplicationProvider.getApplicationContext<Context>()
+        val uri = Uri.parse("content://test/playlist.m3u")
+        val shadowResolver = Shadows.shadowOf(baseContext.contentResolver)
+        shadowResolver.registerInputStreamSupplier(uri) {
+            throw FileNotFoundException("nope")
+        }
+        val service = PlaylistService()
+
+        val results = service.readPlaylist(baseContext, uri)
+
+        assertTrue(results.isEmpty())
+    }
+
+    @Test
+    fun readPlaylist_returnsEmptyOnIOException() {
+        val baseContext = ApplicationProvider.getApplicationContext<Context>()
+        val uri = Uri.parse("content://test/playlist.m3u")
+        val shadowResolver = Shadows.shadowOf(baseContext.contentResolver)
+        shadowResolver.registerInputStreamSupplier(uri) {
+            throw IOException("nope")
+        }
+        val service = PlaylistService()
+
+        val results = service.readPlaylist(baseContext, uri)
+
+        assertTrue(results.isEmpty())
+    }
+
+    @Test
+    fun readPlaylist_returnsEmptyOnReadIOException() {
+        val baseContext = ApplicationProvider.getApplicationContext<Context>()
+        val uri = Uri.parse("content://test/playlist.m3u")
+        val shadowResolver = Shadows.shadowOf(baseContext.contentResolver)
+        shadowResolver.registerInputStreamSupplier(uri) {
+            object : java.io.InputStream() {
+                override fun read(): Int {
+                    throw IOException("read error")
+                }
+            }
         }
         val service = PlaylistService()
 


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: Missing error tests in `PlaylistService.kt` for `readPlaylist`'s execution path when encountering `FileNotFoundException` and `IOException` during stream opening, and `IOException` during stream reading.

📊 **Coverage:** What scenarios are now tested: `FileNotFoundException` thrown during `contentResolver.openInputStream(playlistUri)`, `IOException` thrown during `contentResolver.openInputStream(playlistUri)`, and `IOException` thrown during `reader.lineSequence().forEach { ... }` (simulated by throwing `IOException` from the underlying `InputStream.read()`).

✨ **Result:** The improvement in test coverage: Better safety net for `PlaylistService` and confident refactoring, as the fallback behavior (returning an empty list) is now verified for all documented `try-catch` blocks in `readPlaylist`.

---
*PR created automatically by Jules for task [6633079422704065755](https://jules.google.com/task/6633079422704065755) started by @kimptoc*