### PR TITLE
🧪 [testing improvement] Add unit tests for formatDuration in MainScreen.kt

### DIFF
--- a/mobile/src/test/java/com/example/mymediaplayer/MainScreenTest.kt
+++ b/mobile/src/test/java/com/example/mymediaplayer/MainScreenTest.kt
@@ -1,0 +1,24 @@
+package com.example.mymediaplayer
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.lang.reflect.Method
+
+class MainScreenTest {
+
+    @Test
+    fun testFormatDuration() {
+        val method: Method = Class.forName("com.example.mymediaplayer.MainScreenKt")
+            .getDeclaredMethod("formatDuration", Long::class.java)
+        method.isAccessible = true
+
+        assertEquals("", method.invoke(null, 0L))
+        assertEquals("", method.invoke(null, -100L))
+        assertEquals("0:01", method.invoke(null, 1000L))
+        assertEquals("0:59", method.invoke(null, 59999L))
+        assertEquals("1:00", method.invoke(null, 60000L))
+        assertEquals("1:01", method.invoke(null, 61000L))
+        assertEquals("10:05", method.invoke(null, 605000L))
+        assertEquals("60:00", method.invoke(null, 3600000L))
+    }
+}


### PR DESCRIPTION
🎯 **What:** The `formatDuration` function in `MainScreen.kt` was previously untested, creating a gap in unit test coverage. This is a crucial UI formatting function.
📊 **Coverage:** The new test suite in `MainScreenTest.kt` verifies:
- Duration exactly 0
- Negative durations
- Seconds boundaries (e.g., exactly 1 min, or 59 seconds)
- Standard minute and second formatting
- Hour boundaries
✨ **Result:** We now have 100% coverage over this pure utility method. The tests are written cleanly using Kotlin/Java reflection to avoid mutating the production visibility of the internal method, strictly preserving the original encapsulation while validating exact logic.

---
*PR created automatically by Jules for task [17352416977596500048](https://jules.google.com/task/17352416977596500048) started by @kimptoc*