### PR TITLE
🧪 [testing improvement formatDuration]

### DIFF
--- a/mobile/src/main/java/com/example/mymediaplayer/MainScreen.kt
+++ b/mobile/src/main/java/com/example/mymediaplayer/MainScreen.kt
@@ -2553,7 +2553,8 @@ private fun buildSongDetails(file: MediaFileInfo): String {
     return parts.joinToString(" • ")
 }
 
-private fun formatDuration(durationMs: Long): String {
+@androidx.annotation.VisibleForTesting
+internal fun formatDuration(durationMs: Long): String {
     if (durationMs <= 0L) return ""
     val totalSeconds = durationMs / 1000
     val minutes = totalSeconds / 60

--- a/mobile/src/test/java/com/example/mymediaplayer/MainScreenKtTest.kt
+++ b/mobile/src/test/java/com/example/mymediaplayer/MainScreenKtTest.kt
@@ -1,0 +1,40 @@
+package com.example.mymediaplayer
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import androidx.annotation.VisibleForTesting
+
+class MainScreenKtTest {
+
+    @Test
+    fun formatDuration_handlesNegativeDuration() {
+        assertEquals("", formatDuration(-1000L))
+    }
+
+    @Test
+    fun formatDuration_handlesZeroDuration() {
+        assertEquals("", formatDuration(0L))
+    }
+
+    @Test
+    fun formatDuration_formatsSecondsOnly() {
+        assertEquals("0:45", formatDuration(45000L))
+    }
+
+    @Test
+    fun formatDuration_formatsExactMinute() {
+        assertEquals("1:00", formatDuration(60000L))
+    }
+
+    @Test
+    fun formatDuration_formatsMinutesAndSeconds() {
+        assertEquals("1:05", formatDuration(65000L))
+        assertEquals("3:45", formatDuration(225000L))
+    }
+
+    @Test
+    fun formatDuration_formatsMoreThanAnHour() {
+        // 60 minutes + 5 minutes + 10 seconds = 65 minutes 10 seconds => 3910 seconds = 3910000L
+        assertEquals("65:10", formatDuration(3910000L))
+    }
+}


### PR DESCRIPTION
🎯 **What:** The `formatDuration` function in `MainScreen.kt` was previously untested and private, creating a testing gap for pure formatting logic.

📊 **Coverage:** Added comprehensive JUnit tests for `formatDuration` covering:
*   Negative and zero durations
*   Durations under a minute (seconds only)
*   Exact minute boundaries
*   Minutes and seconds combinations
*   Durations exceeding one hour

✨ **Result:** Increased test coverage by providing a dedicated suite (`MainScreenKtTest`) that validates all edge cases and expected formatting outcomes. Refactored the function visibility to `internal` with `@VisibleForTesting` to enable direct unit testing without reflection.

---
*PR created automatically by Jules for task [10904863077709928262](https://jules.google.com/task/10904863077709928262) started by @kimptoc*