### PR TITLE
🧪 [Testing Improvement] Add comprehensive tests for formatPlaybackDuration

### DIFF
--- a/mobile/src/main/java/com/example/mymediaplayer/MainScreen.kt
+++ b/mobile/src/main/java/com/example/mymediaplayer/MainScreen.kt
@@ -2424,7 +2424,7 @@ private fun ExpandedNowPlayingDialog(
     )
 }
 
-private fun formatPlaybackDuration(durationMs: Long): String {
+internal fun formatPlaybackDuration(durationMs: Long): String {
     val totalSeconds = (durationMs / 1000L).coerceAtLeast(0L)
     val minutes = totalSeconds / 60L
     val seconds = totalSeconds % 60L

--- a/mobile/src/test/java/com/example/mymediaplayer/MainScreenTest.kt
+++ b/mobile/src/test/java/com/example/mymediaplayer/MainScreenTest.kt
@@ -1,0 +1,55 @@
+package com.example.mymediaplayer
+
+import org.junit.Test
+import org.junit.Assert.assertEquals
+
+class MainScreenTest {
+
+    @Test
+    fun formatPlaybackDuration_zeroMs() {
+        assertEquals("0:00", formatPlaybackDuration(0L))
+    }
+
+    @Test
+    fun formatPlaybackDuration_lessThanOneSecond() {
+        assertEquals("0:00", formatPlaybackDuration(999L))
+    }
+
+    @Test
+    fun formatPlaybackDuration_exactlyOneSecond() {
+        assertEquals("0:01", formatPlaybackDuration(1000L))
+    }
+
+    @Test
+    fun formatPlaybackDuration_lessThanOneMinute() {
+        assertEquals("0:59", formatPlaybackDuration(59000L))
+    }
+
+    @Test
+    fun formatPlaybackDuration_exactlyOneMinute() {
+        assertEquals("1:00", formatPlaybackDuration(60000L))
+    }
+
+    @Test
+    fun formatPlaybackDuration_moreThanOneMinute() {
+        assertEquals("1:05", formatPlaybackDuration(65000L))
+    }
+
+    @Test
+    fun formatPlaybackDuration_moreThanTenMinutes() {
+        assertEquals("10:05", formatPlaybackDuration(605000L))
+    }
+
+    @Test
+    fun formatPlaybackDuration_moreThanOneHour() {
+        // 60 minutes * 60 seconds = 3600 seconds = 3600000 ms
+        // 1 hour, 1 minute, 1 second = 3600 + 60 + 1 = 3661 seconds = 3661000 ms
+        assertEquals("61:01", formatPlaybackDuration(3661000L))
+    }
+
+    @Test
+    fun formatPlaybackDuration_negativeMs() {
+        // coerceAtLeast(0L) should handle this
+        assertEquals("0:00", formatPlaybackDuration(-1000L))
+    }
+}


### PR DESCRIPTION
🎯 **What:** The `formatPlaybackDuration` function in `MainScreen.kt` was previously untested. This PR changes its visibility to `internal` so that tests can access it within the same module, and introduces `MainScreenTest.kt` to thoroughly verify its behavior.

📊 **Coverage:** The new test file covers:
- Zero duration (`0` ms)
- Sub-second durations (`999` ms)
- Exactly one second (`1000` ms)
- Sub-minute durations (`59000` ms)
- Exactly one minute (`60000` ms)
- Multi-minute durations (`65000` ms)
- Durations > 10 minutes (`605000` ms)
- Durations > 1 hour (`3661000` ms)
- Negative durations (`-1000` ms, handling via `coerceAtLeast(0L)`)

✨ **Result:** Enhanced test coverage for UI formatting logic, ensuring safe refactoring and robustness against future changes.

---
*PR created automatically by Jules for task [2143351729225601021](https://jules.google.com/task/2143351729225601021) started by @kimptoc*