### PR TITLE
🧹 [Extract MediaPlayerAppContent for maintainability]

### DIFF
--- a/mobile/src/main/java/com/example/mymediaplayer/MainActivity.kt
+++ b/mobile/src/main/java/com/example/mymediaplayer/MainActivity.kt
@@ -290,130 +290,140 @@ class MainActivity : ComponentActivity() {
         MaterialTheme {
             val uiState = viewModel.uiState.collectAsState()
             if (showSettings.value) {
-                SettingsScreen(
-                    trackVoiceIntroEnabled = trackVoiceIntroEnabled.value,
-                    trackVoiceOutroEnabled = trackVoiceOutroEnabled.value,
-                    onToggleTrackVoiceIntro = { toggleTrackVoiceIntro() },
-                    onToggleTrackVoiceOutro = { toggleTrackVoiceOutro() },
-                    cloudAnnouncementKiloKey = cloudAnnouncementKiloKey.value,
-                    cloudAnnouncementTtsKey = cloudAnnouncementTtsKey.value,
-                    debugCloudAnnouncements = debugCloudAnnouncements.value,
-                    onSetDebugCloudAnnouncements = { enabled ->
-                        debugCloudAnnouncements.value = enabled
-                        getSharedPreferences(PREFS_NAME, MODE_PRIVATE).edit {
-                            putBoolean(KEY_DEBUG_CLOUD_ANNOUNCEMENTS, enabled)
-                        }
-                        sendDebugCloudSettingToService(enabled)
-                    },
-                    onSaveCloudAnnouncementKeys = ::saveCloudAnnouncementKeys,
-                    bluetoothAutoPlayEnabled = bluetoothAutoPlayEnabled.value,
-                    onToggleBluetoothAutoPlay = { toggleBluetoothAutoPlay() },
-                    onAddCurrentBluetoothDevice = { addCurrentBluetoothDeviceToAllowlist() },
-                    trustedBluetoothDevices = trustedBluetoothDevices.value,
-                    bluetoothDiagnostics = bluetoothDiagnostics.value,
-                    onRemoveTrustedBluetoothDevice = { address -> removeTrustedBluetoothDevice(address) },
-                    onClearTrustedBluetoothDevices = { clearTrustedBluetoothDevices() },
-                    onRefreshBluetoothDiagnostics = { refreshBluetoothState() },
-                    onChoosePlaylistSaveFolder = { openPlaylistDocumentTree.launch(null) },
-                    onBack = { showSettings.value = false }
-                )
+                SettingsAppContent()
             } else {
-                MainScreen(
-                    uiState = uiState.value,
-                    onSelectFolderWithLimit = { limit, deepScan ->
-                        pendingScanLimit = limit
-                        pendingDeepScan = deepScan
-                        openDocumentTree.launch(null)
-                    },
-                    onChoosePlaylistSaveFolder = {
-                        openPlaylistDocumentTree.launch(null)
-                    },
-                    onScanWholeDriveWithLimit = ::handleScanWholeDriveWithLimit,
-                    onFileClick = { file -> playFile(file, uiState.value.scan.scannedFiles) },
-                    onPlayPause = { togglePlayPause(uiState.value.playback.isPlaying) },
-                    onStop = { stopPlayback() },
-                    onNext = { skipToNext() },
-                    onPrev = { skipToPrevious() },
-                    onToggleRepeat = { toggleRepeatMode(uiState.value.playback.repeatMode) },
-                    onQueueItemSelected = { queueId -> skipToQueueItem(queueId) },
-                    onSeekTo = { positionMs -> seekTo(positionMs) },
-                    onCreatePlaylist = { count -> viewModel.createRandomPlaylist(count) },
-                    onPlaylistMessageDismissed = { viewModel.clearPlaylistMessage() },
-                    onFolderMessageDismissed = { viewModel.clearFolderMessage() },
-                    onScanMessageDismissed = { viewModel.clearScanMessage() },
-                    onTabSelected = { viewModel.selectTab(it) },
-                    onAlbumSelected = { viewModel.selectAlbum(it) },
-                    onAlbumSortModeChanged = { viewModel.setAlbumSortMode(it) },
-                    onGenreSelected = { viewModel.selectGenre(it) },
-                    onArtistSelected = { viewModel.selectArtist(it) },
-                    onSearchQueryChanged = { viewModel.updateSearchQuery(it) },
-                    onClearSearch = { viewModel.clearSearch() },
-                    onClearCategorySelection = { viewModel.clearCategorySelection() },
-                    onPlaylistSelected = { viewModel.selectPlaylist(it) },
-                    onClearPlaylistSelection = { viewModel.clearSelectedPlaylist() },
-                    onDeletePlaylist = { playlist -> viewModel.deletePlaylist(playlist) },
-                    onRenamePlaylist = { playlist, newName ->
-                        viewModel.renamePlaylist(playlist, newName)
-                    },
-                    onSavePlaylistEdits = { playlist, songs ->
-                        viewModel.savePlaylistEdits(playlist, songs)
-                    },
-                    onPlaySongs = { songs ->
-                        playUiList(
-                            songs = songs,
-                            shuffle = false,
-                            queueTitle = queueTitleForCurrentUiList(uiState.value)
-                        )
-                    },
-                    onShuffleSongs = { songs ->
-                        playUiList(
-                            songs = songs,
-                            shuffle = true,
-                            queueTitle = queueTitleForCurrentUiList(uiState.value)
-                        )
-                    },
-                    onPlaySearchResults = { songs ->
-                        playSearchResults(songs, shuffle = false)
-                    },
-                    onShuffleSearchResults = { songs ->
-                        playSearchResults(songs, shuffle = true)
-                    },
-                    onAddToExistingPlaylist = { playlist, files ->
-                        viewModel.addManyToExistingPlaylist(playlist, files)
-                    },
-                    onCreatePlaylistFromSongs = { name, files ->
-                        viewModel.createPlaylistFromSongs(name, files)
-                    },
-                    onToggleFavorite = { file ->
-                        viewModel.toggleFavorite(file.uriString)
-                    },
-                    nowPlayingArt = nowPlayingArt.value,
-                    showPlaylistSaveFolderPrompt = showPlaylistSaveFolderPrompt.value,
-                    onDismissPlaylistSaveFolderPrompt = {
-                        showPlaylistSaveFolderPrompt.value = false
-                    },
-                    onSetPlaylistSaveFolderNow = {
-                        showPlaylistSaveFolderPrompt.value = false
-                        openPlaylistDocumentTree.launch(null)
-                    },
-                    onOpenSettings = { showSettings.value = true },
-                    onPlayPlaylist = { playlist ->
-                        sendFilesToServiceIfNeeded(uiState.value.scan.scannedFiles)
-                        sendPlaylistsToServiceIfNeeded(uiState.value.scan.discoveredPlaylists)
-                        val mediaId = getPlaylistMediaId(playlist.uriString)
-                        mediaController?.transportControls?.playFromMediaId(mediaId, null)
-                    },
-                    onShufflePlaylistSongs = { playlist, songs ->
-                        if (songs.isNotEmpty()) {
-                            sendFilesToServiceIfNeeded(uiState.value.scan.scannedFiles)
-                            sendPlaylistsToServiceIfNeeded(uiState.value.scan.discoveredPlaylists)
-                            val mediaId = getPlaylistShuffleMediaId(playlist.uriString)
-                            mediaController?.transportControls?.playFromMediaId(mediaId, null)
-                        }
-                    }
-                )
+                MainAppContent(uiState.value)
             }
         }
+    }
+
+    @androidx.compose.runtime.Composable
+    private fun SettingsAppContent() {
+        SettingsScreen(
+            trackVoiceIntroEnabled = trackVoiceIntroEnabled.value,
+            trackVoiceOutroEnabled = trackVoiceOutroEnabled.value,
+            onToggleTrackVoiceIntro = { toggleTrackVoiceIntro() },
+            onToggleTrackVoiceOutro = { toggleTrackVoiceOutro() },
+            cloudAnnouncementKiloKey = cloudAnnouncementKiloKey.value,
+            cloudAnnouncementTtsKey = cloudAnnouncementTtsKey.value,
+            debugCloudAnnouncements = debugCloudAnnouncements.value,
+            onSetDebugCloudAnnouncements = { enabled ->
+                debugCloudAnnouncements.value = enabled
+                getSharedPreferences(PREFS_NAME, MODE_PRIVATE).edit {
+                    putBoolean(KEY_DEBUG_CLOUD_ANNOUNCEMENTS, enabled)
+                }
+                sendDebugCloudSettingToService(enabled)
+            },
+            onSaveCloudAnnouncementKeys = ::saveCloudAnnouncementKeys,
+            bluetoothAutoPlayEnabled = bluetoothAutoPlayEnabled.value,
+            onToggleBluetoothAutoPlay = { toggleBluetoothAutoPlay() },
+            onAddCurrentBluetoothDevice = { addCurrentBluetoothDeviceToAllowlist() },
+            trustedBluetoothDevices = trustedBluetoothDevices.value,
+            bluetoothDiagnostics = bluetoothDiagnostics.value,
+            onRemoveTrustedBluetoothDevice = { address -> removeTrustedBluetoothDevice(address) },
+            onClearTrustedBluetoothDevices = { clearTrustedBluetoothDevices() },
+            onRefreshBluetoothDiagnostics = { refreshBluetoothState() },
+            onChoosePlaylistSaveFolder = { openPlaylistDocumentTree.launch(null) },
+            onBack = { showSettings.value = false }
+        )
+    }
+
+    @androidx.compose.runtime.Composable
+    private fun MainAppContent(uiState: MainUiState) {
+        MainScreen(
+            uiState = uiState,
+            onSelectFolderWithLimit = { limit, deepScan ->
+                pendingScanLimit = limit
+                pendingDeepScan = deepScan
+                openDocumentTree.launch(null)
+            },
+            onChoosePlaylistSaveFolder = {
+                openPlaylistDocumentTree.launch(null)
+            },
+            onScanWholeDriveWithLimit = ::handleScanWholeDriveWithLimit,
+            onFileClick = { file -> playFile(file, uiState.scan.scannedFiles) },
+            onPlayPause = { togglePlayPause(uiState.playback.isPlaying) },
+            onStop = { stopPlayback() },
+            onNext = { skipToNext() },
+            onPrev = { skipToPrevious() },
+            onToggleRepeat = { toggleRepeatMode(uiState.playback.repeatMode) },
+            onQueueItemSelected = { queueId -> skipToQueueItem(queueId) },
+            onSeekTo = { positionMs -> seekTo(positionMs) },
+            onCreatePlaylist = { count -> viewModel.createRandomPlaylist(count) },
+            onPlaylistMessageDismissed = { viewModel.clearPlaylistMessage() },
+            onFolderMessageDismissed = { viewModel.clearFolderMessage() },
+            onScanMessageDismissed = { viewModel.clearScanMessage() },
+            onTabSelected = { viewModel.selectTab(it) },
+            onAlbumSelected = { viewModel.selectAlbum(it) },
+            onAlbumSortModeChanged = { viewModel.setAlbumSortMode(it) },
+            onGenreSelected = { viewModel.selectGenre(it) },
+            onArtistSelected = { viewModel.selectArtist(it) },
+            onSearchQueryChanged = { viewModel.updateSearchQuery(it) },
+            onClearSearch = { viewModel.clearSearch() },
+            onClearCategorySelection = { viewModel.clearCategorySelection() },
+            onPlaylistSelected = { viewModel.selectPlaylist(it) },
+            onClearPlaylistSelection = { viewModel.clearSelectedPlaylist() },
+            onDeletePlaylist = { playlist -> viewModel.deletePlaylist(playlist) },
+            onRenamePlaylist = { playlist, newName ->
+                viewModel.renamePlaylist(playlist, newName)
+            },
+            onSavePlaylistEdits = { playlist, songs ->
+                viewModel.savePlaylistEdits(playlist, songs)
+            },
+            onPlaySongs = { songs ->
+                playUiList(
+                    songs = songs,
+                    shuffle = false,
+                    queueTitle = queueTitleForCurrentUiList(uiState)
+                )
+            },
+            onShuffleSongs = { songs ->
+                playUiList(
+                    songs = songs,
+                    shuffle = true,
+                    queueTitle = queueTitleForCurrentUiList(uiState)
+                )
+            },
+            onPlaySearchResults = { songs ->
+                playSearchResults(songs, shuffle = false)
+            },
+            onShuffleSearchResults = { songs ->
+                playSearchResults(songs, shuffle = true)
+            },
+            onAddToExistingPlaylist = { playlist, files ->
+                viewModel.addManyToExistingPlaylist(playlist, files)
+            },
+            onCreatePlaylistFromSongs = { name, files ->
+                viewModel.createPlaylistFromSongs(name, files)
+            },
+            onToggleFavorite = { file ->
+                viewModel.toggleFavorite(file.uriString)
+            },
+            nowPlayingArt = nowPlayingArt.value,
+            showPlaylistSaveFolderPrompt = showPlaylistSaveFolderPrompt.value,
+            onDismissPlaylistSaveFolderPrompt = {
+                showPlaylistSaveFolderPrompt.value = false
+            },
+            onSetPlaylistSaveFolderNow = {
+                showPlaylistSaveFolderPrompt.value = false
+                openPlaylistDocumentTree.launch(null)
+            },
+            onOpenSettings = { showSettings.value = true },
+            onPlayPlaylist = { playlist ->
+                sendFilesToServiceIfNeeded(uiState.scan.scannedFiles)
+                sendPlaylistsToServiceIfNeeded(uiState.scan.discoveredPlaylists)
+                val mediaId = getPlaylistMediaId(playlist.uriString)
+                mediaController?.transportControls?.playFromMediaId(mediaId, null)
+            },
+            onShufflePlaylistSongs = { playlist, songs ->
+                if (songs.isNotEmpty()) {
+                    sendFilesToServiceIfNeeded(uiState.scan.scannedFiles)
+                    sendPlaylistsToServiceIfNeeded(uiState.scan.discoveredPlaylists)
+                    val mediaId = getPlaylistShuffleMediaId(playlist.uriString)
+                    mediaController?.transportControls?.playFromMediaId(mediaId, null)
+                }
+            }
+        )
     }
 
     private fun playFile(


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
The `MediaPlayerAppContent` `@Composable` inside `MainActivity` was a massive block containing logic for both `SettingsScreen` and `MainScreen`. It was extracted into two smaller, private `@Composable` member functions `SettingsAppContent` and `MainAppContent`.

💡 **Why:** How this improves maintainability
Extracting the code resolves the Long Function code smell, makes the `MainActivity` file much more scannable, and adheres to standard Jetpack Compose modularization patterns.

✅ **Verification:** How you confirmed the change is safe
- Extracted functions remain `private` and `@Composable` inside `MainActivity`, retaining the exact same member variable access.
- Confirmed with `git diff HEAD` that code matches correctly.
- Confirmed `./gradlew build` passes.

✨ **Result:** The improvement achieved
The codebase is now cleaner, easier to maintain, and the size of `MediaPlayerAppContent` is tiny.

---
*PR created automatically by Jules for task [2087126142417113402](https://jules.google.com/task/2087126142417113402) started by @kimptoc*