### PR TITLE
🧪 [testing improvement] Add writePlaylistWithName error tests

### DIFF
--- a/shared/src/test/java/com/example/mymediaplayer/shared/PlaylistServiceTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/PlaylistServiceTest.kt
@@ -11,8 +11,24 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.Implementation
+import org.robolectric.annotation.Implements
+import androidx.documentfile.provider.DocumentFile
+
+@Implements(className = "androidx.documentfile.provider.TreeDocumentFile")
+class ShadowTreeDocumentFile {
+    @Implementation
+    fun createFile(mimeType: String, displayName: String): DocumentFile? {
+        return DocumentFile.fromSingleUri(
+            androidx.test.core.app.ApplicationProvider.getApplicationContext(),
+            android.net.Uri.parse("content://mock/playlist.m3u")
+        )
+    }
+}
 
 @RunWith(RobolectricTestRunner::class)
+@Config(shadows = [ShadowTreeDocumentFile::class])
 class PlaylistServiceTest {
 
     @Test
@@ -76,6 +92,42 @@ class PlaylistServiceTest {
         val files = emptyList<MediaFileInfo>()
 
         val result = service.writePlaylistWithName(baseContext, treeUri, files, "test_playlist")
+
+        assertNull(result)
+    }
+
+    @Test
+    fun writePlaylistWithName_returnsNullOnSecurityException() {
+        val baseContext = ApplicationProvider.getApplicationContext<Context>()
+        val shadowResolver = Shadows.shadowOf(baseContext.contentResolver)
+
+        val service = PlaylistService()
+        val files = listOf(MediaFileInfo("content://test/song1", "Song One", 1L, "Song One"))
+
+        val uri = Uri.parse("content://mock/playlist.m3u")
+        shadowResolver.registerOutputStreamSupplier(uri) {
+            throw SecurityException("Mocked SecurityException")
+        }
+
+        val result = service.writePlaylistWithName(baseContext, Uri.parse("content://mock/tree"), files, "test_playlist")
+
+        assertNull(result)
+    }
+
+    @Test
+    fun writePlaylistWithName_returnsNullOnIOException() {
+        val baseContext = ApplicationProvider.getApplicationContext<Context>()
+        val shadowResolver = Shadows.shadowOf(baseContext.contentResolver)
+
+        val service = PlaylistService()
+        val files = listOf(MediaFileInfo("content://test/song1", "Song One", 1L, "Song One"))
+
+        val uri = Uri.parse("content://mock/playlist.m3u")
+        shadowResolver.registerOutputStreamSupplier(uri) {
+            throw IOException("Mocked IOException")
+        }
+
+        val result = service.writePlaylistWithName(baseContext, Uri.parse("content://mock/tree"), files, "test_playlist")
 
         assertNull(result)
     }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was missing tests for the `SecurityException` and `IOException` cases when attempting to write a playlist in `PlaylistService.writePlaylistWithName`.

📊 **Coverage:** The scenarios now tested are `writePlaylistWithName_returnsNullOnSecurityException` and `writePlaylistWithName_returnsNullOnIOException`. They ensure the method correctly catches the exceptions when `contentResolver.openOutputStream` fails and logs the error, returning `null`.

✨ **Result:** Test coverage improved for error handling branches in playlist creation.

---
*PR created automatically by Jules for task [1829416355754995857](https://jules.google.com/task/1829416355754995857) started by @kimptoc*