### PR TITLE
🧪 [Testing Improvement] Add error handling tests for writing playlists

### DIFF
--- a/shared/src/test/java/androidx/documentfile/provider/MockDocumentFile.kt
+++ b/shared/src/test/java/androidx/documentfile/provider/MockDocumentFile.kt
@@ -1,0 +1,26 @@
+package androidx.documentfile.provider
+
+import android.net.Uri
+
+class MockDocumentFile(parent: DocumentFile?, val mockUri: Uri, val mockName: String) : DocumentFile(parent) {
+    override fun createFile(mimeType: String, displayName: String): DocumentFile? {
+        val childUri = Uri.parse("$mockUri/$displayName")
+        return MockDocumentFile(this, childUri, displayName)
+    }
+
+    override fun createDirectory(displayName: String): DocumentFile? = null
+    override fun getUri(): Uri = mockUri
+    override fun getName(): String = mockName
+    override fun getType(): String? = null
+    override fun isDirectory(): Boolean = true
+    override fun isFile(): Boolean = false
+    override fun isVirtual(): Boolean = false
+    override fun lastModified(): Long = 0L
+    override fun length(): Long = 0L
+    override fun canRead(): Boolean = true
+    override fun canWrite(): Boolean = true
+    override fun delete(): Boolean = true
+    override fun exists(): Boolean = true
+    override fun listFiles(): Array<DocumentFile> = arrayOf()
+    override fun renameTo(displayName: String): Boolean = true
+}

--- a/shared/src/test/java/com/example/mymediaplayer/shared/PlaylistServiceTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/PlaylistServiceTest.kt
@@ -182,6 +182,70 @@ class PlaylistServiceTest {
         assertFalse(result)
     }
 
+    @org.robolectric.annotation.Config(shadows = [ShadowDocumentFile::class])
+    @Test
+    fun writePlaylistWithName_returnsNullOnSecurityException() {
+        val baseContext = ApplicationProvider.getApplicationContext<Context>()
+        val treeUri = Uri.parse("content://mock/tree")
+        val service = PlaylistService()
+        val files = listOf(MediaFileInfo("content://test/song1", "Song One", 1L, "Song One"))
+
+        val mockRoot = androidx.documentfile.provider.MockDocumentFile(null, treeUri, "tree")
+        ShadowDocumentFile.mockRoot = mockRoot
+
+        try {
+            val targetUri = Uri.parse("$treeUri/test_playlist.m3u")
+            val shadowResolver = Shadows.shadowOf(baseContext.contentResolver)
+            shadowResolver.registerOutputStreamSupplier(targetUri) {
+                object : java.io.OutputStream() {
+                    override fun write(b: Int) {
+                        throw SecurityException("Security exception thrown from write")
+                    }
+                    override fun write(b: ByteArray) {
+                        throw SecurityException("Security exception thrown from write array")
+                    }
+                }
+            }
+
+            val result = service.writePlaylistWithName(baseContext, treeUri, files, "test_playlist")
+            assertNull(result)
+        } finally {
+            ShadowDocumentFile.mockRoot = null
+        }
+    }
+
+    @org.robolectric.annotation.Config(shadows = [ShadowDocumentFile::class])
+    @Test
+    fun writePlaylistWithName_returnsNullOnIOException() {
+        val baseContext = ApplicationProvider.getApplicationContext<Context>()
+        val treeUri = Uri.parse("content://mock/tree")
+        val service = PlaylistService()
+        val files = listOf(MediaFileInfo("content://test/song1", "Song One", 1L, "Song One"))
+
+        val mockRoot = androidx.documentfile.provider.MockDocumentFile(null, treeUri, "tree")
+        ShadowDocumentFile.mockRoot = mockRoot
+
+        try {
+            val targetUri = Uri.parse("$treeUri/test_playlist.m3u")
+            val shadowResolver = Shadows.shadowOf(baseContext.contentResolver)
+            shadowResolver.registerOutputStreamSupplier(targetUri) {
+                object : java.io.OutputStream() {
+                    override fun write(b: Int) {
+                        throw IOException("IO exception thrown from write")
+                    }
+                    override fun write(b: ByteArray) {
+                        throw IOException("IO exception thrown from write array")
+                    }
+                }
+            }
+
+            val result = service.writePlaylistWithName(baseContext, treeUri, files, "test_playlist")
+            assertNull(result)
+        } finally {
+            ShadowDocumentFile.mockRoot = null
+        }
+    }
+
     @Test
     fun overwritePlaylist_returnsTrueOnSuccess() {
         val baseContext = ApplicationProvider.getApplicationContext<Context>()


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the missing error handling tests in `PlaylistService.kt` for `writePlaylistWithName` (or `writePlaylist`) when a `SecurityException` or `IOException` occurs during the creation or writing of the file.

📊 **Coverage:** The tests now simulate `SecurityException` and `IOException` occurring inside the `OutputStream.write()` method for `content://` URIs created through `DocumentFile`. This perfectly covers the `catch` blocks in `PlaylistService`.

✨ **Result:** The test coverage for `PlaylistService` is improved by thoroughly validating error paths, ensuring the application gracefully falls back and returns `null` rather than crashing when filesystem or permission errors occur.

---
*PR created automatically by Jules for task [4083457941242467636](https://jules.google.com/task/4083457941242467636) started by @kimptoc*