### PR TITLE
Return read-only media item lists from MyMusicService

### DIFF
--- a/shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
@@ -833,7 +833,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
         result.sendResult(items)
     }
 
-    private fun buildMediaItemsForPrefix(parentId: String): MutableList<MediaItem>? {
+    private fun buildMediaItemsForPrefix(parentId: String): List<MediaItem>? {
         return when {
             parentId.startsWith(SMART_PLAYLIST_PREFIX) -> buildMediaItemsForSmartPlaylist(parentId)
             parentId.startsWith(PLAYLIST_PREFIX) -> buildMediaItemsForPlaylist(parentId)
@@ -850,7 +850,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
         }
     }
 
-    private fun buildMediaItemsForSmartPlaylist(parentId: String): MutableList<MediaItem> {
+    private fun buildMediaItemsForSmartPlaylist(parentId: String): List<MediaItem> {
             val smartId = Uri.decode(parentId.removePrefix(SMART_PLAYLIST_PREFIX))
             val tracks = resolveSmartPlaylistTracksById(smartId) ?: emptyList()
             return buildSongListItems(
@@ -860,7 +860,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
             )
     }
 
-    private fun buildMediaItemsForPlaylist(parentId: String): MutableList<MediaItem> {
+    private fun buildMediaItemsForPlaylist(parentId: String): List<MediaItem> {
             val shortId = parentId.removePrefix(PLAYLIST_PREFIX)
             val playlistUri = playlistShortIds[shortId] ?: return mutableListOf()
             val songs = enrichFromCache(
@@ -870,13 +870,13 @@ class MyMusicService : MediaBrowserServiceCompat() {
             return buildSongListItems(songs, PLAYLIST_SHORT_PREFIX + shortId, songIconUri)
     }
 
-    private fun buildMediaItemsForAlbum(parentId: String): MutableList<MediaItem> {
+    private fun buildMediaItemsForAlbum(parentId: String): List<MediaItem> {
             ensureMetadataIndexes()
             val album = Uri.decode(parentId.removePrefix(ALBUM_PREFIX))
             return buildSongListItems(mediaCacheService.songsForAlbum(album), ALBUM_PREFIX + Uri.encode(album), resourceIconUri(R.drawable.ic_album_placeholder))
     }
 
-    private fun buildMediaItemsForGenre(parentId: String): MutableList<MediaItem> {
+    private fun buildMediaItemsForGenre(parentId: String): List<MediaItem> {
             ensureMetadataIndexes()
             val genre = Uri.decode(parentId.removePrefix(GENRE_PREFIX))
             val songs = mediaCacheService.songsForGenre(genre)
@@ -890,7 +890,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
             return buildSongListItems(songs, GENRE_PREFIX + Uri.encode(genre), resourceIconUri(R.drawable.ic_album_placeholder))
     }
 
-    private fun buildMediaItemsForGenreSongLetter(parentId: String): MutableList<MediaItem> {
+    private fun buildMediaItemsForGenreSongLetter(parentId: String): List<MediaItem> {
             ensureMetadataIndexes()
             val parts = parseBucketParts(parentId, GENRE_SONG_LETTER_PREFIX) ?: return mutableListOf()
             val genre = parts.first
@@ -903,13 +903,13 @@ class MyMusicService : MediaBrowserServiceCompat() {
             )
     }
 
-    private fun buildMediaItemsForArtist(parentId: String): MutableList<MediaItem> {
+    private fun buildMediaItemsForArtist(parentId: String): List<MediaItem> {
             ensureMetadataIndexes()
             val artist = Uri.decode(parentId.removePrefix(ARTIST_PREFIX))
             return buildSongListItems(mediaCacheService.songsForArtist(artist), ARTIST_PREFIX + Uri.encode(artist), resourceIconUri(R.drawable.ic_album_placeholder))
     }
 
-    private fun buildMediaItemsForArtistLetter(parentId: String): MutableList<MediaItem> {
+    private fun buildMediaItemsForArtistLetter(parentId: String): List<MediaItem> {
             ensureMetadataIndexes()
             val letter = Uri.decode(parentId.removePrefix(ARTIST_LETTER_PREFIX))
             return buildCategoryListItems(
@@ -920,7 +920,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
             )
     }
 
-    private fun buildMediaItemsForDecade(parentId: String): MutableList<MediaItem> {
+    private fun buildMediaItemsForDecade(parentId: String): List<MediaItem> {
             ensureMetadataIndexes()
             val decade = Uri.decode(parentId.removePrefix(DECADE_PREFIX))
             val songs = mediaCacheService.songsForDecade(decade)
@@ -934,7 +934,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
             return buildSongListItems(songs, DECADE_PREFIX + Uri.encode(decade), resourceIconUri(R.drawable.ic_album_placeholder))
     }
 
-    private fun buildMediaItemsForDecadeSongLetter(parentId: String): MutableList<MediaItem> {
+    private fun buildMediaItemsForDecadeSongLetter(parentId: String): List<MediaItem> {
             ensureMetadataIndexes()
             val parts = parseBucketParts(parentId, DECADE_SONG_LETTER_PREFIX) ?: return mutableListOf()
             val decade = parts.first
@@ -947,7 +947,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
             )
     }
 
-    private fun buildMediaItemsForGenreLetter(parentId: String): MutableList<MediaItem> {
+    private fun buildMediaItemsForGenreLetter(parentId: String): List<MediaItem> {
             ensureMetadataIndexes()
             val letter = Uri.decode(parentId.removePrefix(GENRE_LETTER_PREFIX))
             return buildCategoryListItems(
@@ -957,7 +957,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
             )
     }
 
-    private fun buildMediaItemsForSongLetter(parentId: String): MutableList<MediaItem> {
+    private fun buildMediaItemsForSongLetter(parentId: String): List<MediaItem> {
             val letter = Uri.decode(parentId.removePrefix(SONG_LETTER_PREFIX))
             val filtered = filterSongsByLetter(mediaCacheService.cachedFiles, letter)
             return buildSongLetterItems(
@@ -966,7 +966,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
             )
     }
 
-    private fun buildMediaItemsForId(parentId: String): MutableList<MediaItem> {
+    private fun buildMediaItemsForId(parentId: String): List<MediaItem> {
         return when (parentId) {
             ROOT_ID -> buildRootItems()
             HOME_ID -> buildHomeItems()
@@ -982,7 +982,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
         }
     }
 
-    private fun buildRootItems(): MutableList<MediaItem> {
+    private fun buildRootItems(): List<MediaItem> {
         val items = mutableListOf<MediaItem>()
         items.add(
             MediaItem(
@@ -1011,7 +1011,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
         return items
     }
 
-    private fun buildSongsItems(): MutableList<MediaItem> {
+    private fun buildSongsItems(): List<MediaItem> {
         val items = mutableListOf<MediaItem>()
         if (mediaCacheService.cachedFiles.isNotEmpty()) {
             items.add(
@@ -1046,7 +1046,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
         return items
     }
 
-    private fun buildSongsAllItems(): MutableList<MediaItem> {
+    private fun buildSongsAllItems(): List<MediaItem> {
         val titles = mediaCacheService.cachedFiles.map { it.cleanTitle }
         return buildCategoryListItems(
             buildLetterBuckets(titles),
@@ -1055,7 +1055,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
         )
     }
 
-    private fun buildPlaylistsItems(): MutableList<MediaItem> {
+    private fun buildPlaylistsItems(): List<MediaItem> {
         return playlistEntriesForBrowse(mediaCacheService.discoveredPlaylists).map { entry ->
             val description = MediaDescriptionCompat.Builder()
                 .setMediaId(entry.mediaId)
@@ -1063,10 +1063,10 @@ class MyMusicService : MediaBrowserServiceCompat() {
                 .setIconUri(resourceIconUri(R.drawable.ic_auto_playlists))
                 .build()
             MediaItem(description, MediaItem.FLAG_BROWSABLE)
-        }.toMutableList()
+        }
     }
 
-    private fun buildAlbumsItems(): MutableList<MediaItem> {
+    private fun buildAlbumsItems(): List<MediaItem> {
         ensureMetadataIndexes()
         return buildCategoryListItems(
             mediaCacheService.albums(),
@@ -1076,7 +1076,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
         )
     }
 
-    private fun buildGenresItems(): MutableList<MediaItem> {
+    private fun buildGenresItems(): List<MediaItem> {
         ensureMetadataIndexes()
         return buildCategoryListItems(
             mediaCacheService.genres(),
@@ -1086,7 +1086,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
         )
     }
 
-    private fun buildArtistsItems(): MutableList<MediaItem> {
+    private fun buildArtistsItems(): List<MediaItem> {
         ensureMetadataIndexes()
         return buildCategoryListItems(
             buildLetterBuckets(mediaCacheService.artists()),
@@ -1095,7 +1095,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
         )
     }
 
-    private fun buildDecadesItems(): MutableList<MediaItem> {
+    private fun buildDecadesItems(): List<MediaItem> {
         ensureMetadataIndexes()
         return buildCategoryListItems(
             mediaCacheService.decades(),
@@ -1105,7 +1105,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
         )
     }
 
-    private fun buildSearchItems(): MutableList<MediaItem> {
+    private fun buildSearchItems(): List<MediaItem> {
         return mutableListOf(
             MediaItem(
                 MediaDescriptionCompat.Builder()
@@ -1116,7 +1116,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
             )
         )
     }
-    internal fun buildMediaItems(parentId: String): MutableList<MediaItem> {
+    internal fun buildMediaItems(parentId: String): List<MediaItem> {
         val start = SystemClock.elapsedRealtime()
 
         val prefixItems = buildMediaItemsForPrefix(parentId)
@@ -1288,7 +1288,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
         }.eachCount()
     }
 
-    private fun buildPlayAllShuffleItems(listKey: String): MutableList<MediaItem> {
+    private fun buildPlayAllShuffleItems(listKey: String): List<MediaItem> {
         val items = mutableListOf<MediaItem>()
         items.add(
             MediaItem(
@@ -2907,7 +2907,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
         }
     }
 
-    internal fun buildHomeItems(): MutableList<MediaItem> {
+    internal fun buildHomeItems(): List<MediaItem> {
         val items = mutableListOf<MediaItem>()
         val childListExtras = Bundle().apply {
             putInt(


### PR DESCRIPTION
This updates the MyMusicService browse item builders to expose read-only List<MediaItem> results instead of MutableList<MediaItem>, matching how the returned values are consumed by browse results and callers. It keeps the internal mutable accumulation where needed, removes the redundant mutable conversion from the playlists builder, and verifies that the listed builder functions no longer expose mutable return types. Verification: git diff --check passed; ./gradlew :shared:testDebugUnitTest did not complete successfully locally; see PR body for details.