### PR TITLE
Relax media item builders to return read-only lists

### DIFF
--- a/shared/src/main/java/com/example/mymediaplayer/shared/MediaItemBuilders.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/MediaItemBuilders.kt
@@ -8,7 +8,7 @@ internal fun buildSongListItems(
     songs: List<MediaFileInfo>,
     listKey: String,
     defaultIconUri: Uri? = null
-): MutableList<MediaItem> {
+): List<MediaItem> {
     val items = mutableListOf<MediaItem>()
     if (songs.isNotEmpty()) {
         items.add(
@@ -55,7 +55,7 @@ internal fun buildCategoryListItems(
     prefix: String,
     counts: Map<String, Int>? = null,
     iconUri: Uri? = null
-): MutableList<MediaItem> {
+): List<MediaItem> {
     return categories.map { category ->
         val builder = MediaDescriptionCompat.Builder()
             .setMediaId(prefix + Uri.encode(category))
@@ -68,5 +68,5 @@ internal fun buildCategoryListItems(
             builder.setIconUri(iconUri)
         }
         MediaItem(builder.build(), MediaItem.FLAG_BROWSABLE)
-    }.toMutableList()
+    }
 }

--- a/shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
@@ -819,7 +819,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
             serviceScope.launch {
                 try {
                     ensureMetadataIndexes()
-                    result.sendResult(buildMediaItems(parentId))
+                    result.sendResult(buildMediaItems(parentId).toMutableList())
                 } catch (e: Exception) {
                     Log.e("MyMusicService", "Failed to build media items for $parentId", e)
                     result.sendResult(mutableListOf())
@@ -828,7 +828,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
             return
         }
 
-        result.sendResult(buildMediaItems(parentId))
+        result.sendResult(buildMediaItems(parentId).toMutableList())
     }
 
     override fun onSearch(query: String, extras: Bundle?, result: Result<MutableList<MediaItem>>) {
@@ -1465,7 +1465,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
             }
 
         for ((parentId, results) in pending) {
-            val items = buildMediaItems(parentId)
+            val items = buildMediaItems(parentId).toMutableList()
             for (result in results) {
                 result.sendResult(items)
             }

--- a/shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
@@ -858,7 +858,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
         result.sendResult(items)
     }
 
-    private fun buildMediaItemsForPrefix(parentId: String): MutableList<MediaItem>? {
+    private fun buildMediaItemsForPrefix(parentId: String): List<MediaItem>? {
         return when {
             parentId.startsWith(SMART_PLAYLIST_PREFIX) -> buildMediaItemsForSmartPlaylist(parentId)
             parentId.startsWith(PLAYLIST_PREFIX) -> buildMediaItemsForPlaylist(parentId)
@@ -875,7 +875,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
         }
     }
 
-    private fun buildMediaItemsForSmartPlaylist(parentId: String): MutableList<MediaItem> {
+    private fun buildMediaItemsForSmartPlaylist(parentId: String): List<MediaItem> {
             val smartId = Uri.decode(parentId.removePrefix(SMART_PLAYLIST_PREFIX))
             val tracks = resolveSmartPlaylistTracksById(smartId) ?: emptyList()
             return buildSongListItems(
@@ -885,7 +885,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
             )
     }
 
-    private fun buildMediaItemsForPlaylist(parentId: String): MutableList<MediaItem> {
+    private fun buildMediaItemsForPlaylist(parentId: String): List<MediaItem> {
             val shortId = parentId.removePrefix(PLAYLIST_PREFIX)
             val playlistUri = playlistShortIds[shortId] ?: return mutableListOf()
             val songs = enrichFromCache(
@@ -895,13 +895,13 @@ class MyMusicService : MediaBrowserServiceCompat() {
             return buildSongListItems(songs, PLAYLIST_SHORT_PREFIX + shortId, songIconUri)
     }
 
-    private fun buildMediaItemsForAlbum(parentId: String): MutableList<MediaItem> {
+    private fun buildMediaItemsForAlbum(parentId: String): List<MediaItem> {
             ensureMetadataIndexes()
             val album = Uri.decode(parentId.removePrefix(ALBUM_PREFIX))
             return buildSongListItems(mediaCacheService.songsForAlbum(album), ALBUM_PREFIX + Uri.encode(album), resourceIconUri(R.drawable.ic_album_placeholder))
     }
 
-    private fun buildMediaItemsForGenre(parentId: String): MutableList<MediaItem> {
+    private fun buildMediaItemsForGenre(parentId: String): List<MediaItem> {
             ensureMetadataIndexes()
             val genre = Uri.decode(parentId.removePrefix(GENRE_PREFIX))
             val songs = mediaCacheService.songsForGenre(genre)
@@ -915,7 +915,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
             return buildSongListItems(songs, GENRE_PREFIX + Uri.encode(genre), resourceIconUri(R.drawable.ic_album_placeholder))
     }
 
-    private fun buildMediaItemsForGenreSongLetter(parentId: String): MutableList<MediaItem> {
+    private fun buildMediaItemsForGenreSongLetter(parentId: String): List<MediaItem> {
             ensureMetadataIndexes()
             val parts = parseBucketParts(parentId, GENRE_SONG_LETTER_PREFIX) ?: return mutableListOf()
             val genre = parts.first
@@ -928,13 +928,13 @@ class MyMusicService : MediaBrowserServiceCompat() {
             )
     }
 
-    private fun buildMediaItemsForArtist(parentId: String): MutableList<MediaItem> {
+    private fun buildMediaItemsForArtist(parentId: String): List<MediaItem> {
             ensureMetadataIndexes()
             val artist = Uri.decode(parentId.removePrefix(ARTIST_PREFIX))
             return buildSongListItems(mediaCacheService.songsForArtist(artist), ARTIST_PREFIX + Uri.encode(artist), resourceIconUri(R.drawable.ic_album_placeholder))
     }
 
-    private fun buildMediaItemsForArtistLetter(parentId: String): MutableList<MediaItem> {
+    private fun buildMediaItemsForArtistLetter(parentId: String): List<MediaItem> {
             ensureMetadataIndexes()
             val letter = Uri.decode(parentId.removePrefix(ARTIST_LETTER_PREFIX))
             return buildCategoryListItems(
@@ -945,7 +945,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
             )
     }
 
-    private fun buildMediaItemsForDecade(parentId: String): MutableList<MediaItem> {
+    private fun buildMediaItemsForDecade(parentId: String): List<MediaItem> {
             ensureMetadataIndexes()
             val decade = Uri.decode(parentId.removePrefix(DECADE_PREFIX))
             val songs = mediaCacheService.songsForDecade(decade)
@@ -959,7 +959,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
             return buildSongListItems(songs, DECADE_PREFIX + Uri.encode(decade), resourceIconUri(R.drawable.ic_album_placeholder))
     }
 
-    private fun buildMediaItemsForDecadeSongLetter(parentId: String): MutableList<MediaItem> {
+    private fun buildMediaItemsForDecadeSongLetter(parentId: String): List<MediaItem> {
             ensureMetadataIndexes()
             val parts = parseBucketParts(parentId, DECADE_SONG_LETTER_PREFIX) ?: return mutableListOf()
             val decade = parts.first
@@ -972,7 +972,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
             )
     }
 
-    private fun buildMediaItemsForGenreLetter(parentId: String): MutableList<MediaItem> {
+    private fun buildMediaItemsForGenreLetter(parentId: String): List<MediaItem> {
             ensureMetadataIndexes()
             val letter = Uri.decode(parentId.removePrefix(GENRE_LETTER_PREFIX))
             return buildCategoryListItems(
@@ -982,7 +982,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
             )
     }
 
-    private fun buildMediaItemsForSongLetter(parentId: String): MutableList<MediaItem> {
+    private fun buildMediaItemsForSongLetter(parentId: String): List<MediaItem> {
             val letter = Uri.decode(parentId.removePrefix(SONG_LETTER_PREFIX))
             val filtered = filterSongsByLetter(mediaCacheService.cachedMusicFiles, letter)
             return buildSongLetterItems(
@@ -991,7 +991,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
             )
     }
 
-    private fun buildMediaItemsForId(parentId: String): MutableList<MediaItem> {
+    private fun buildMediaItemsForId(parentId: String): List<MediaItem> {
         return when (parentId) {
             ROOT_ID -> buildRootItems()
             HOME_ID -> buildHomeItems()
@@ -1007,7 +1007,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
         }
     }
 
-    private fun buildRootItems(): MutableList<MediaItem> {
+    private fun buildRootItems(): List<MediaItem> {
         val items = mutableListOf<MediaItem>()
         items.add(
             MediaItem(
@@ -1036,7 +1036,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
         return items
     }
 
-    private fun buildSongsItems(): MutableList<MediaItem> {
+    private fun buildSongsItems(): List<MediaItem> {
         val items = mutableListOf<MediaItem>()
         if (mediaCacheService.cachedMusicFiles.isNotEmpty()) {
             items.add(
@@ -1071,7 +1071,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
         return items
     }
 
-    private fun buildSongsAllItems(): MutableList<MediaItem> {
+    private fun buildSongsAllItems(): List<MediaItem> {
         val titles = mediaCacheService.cachedMusicFiles.map { it.cleanTitle }
         return buildCategoryListItems(
             buildLetterBuckets(titles),
@@ -1080,7 +1080,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
         )
     }
 
-    private fun buildPlaylistsItems(): MutableList<MediaItem> {
+    private fun buildPlaylistsItems(): List<MediaItem> {
         return playlistEntriesForBrowse(mediaCacheService.discoveredPlaylists).map { entry ->
             val description = MediaDescriptionCompat.Builder()
                 .setMediaId(entry.mediaId)
@@ -1088,10 +1088,10 @@ class MyMusicService : MediaBrowserServiceCompat() {
                 .setIconUri(resourceIconUri(R.drawable.ic_auto_playlists))
                 .build()
             MediaItem(description, MediaItem.FLAG_BROWSABLE)
-        }.toMutableList()
+        }
     }
 
-    private fun buildAlbumsItems(): MutableList<MediaItem> {
+    private fun buildAlbumsItems(): List<MediaItem> {
         ensureMetadataIndexes()
         return buildCategoryListItems(
             mediaCacheService.albums(),
@@ -1101,7 +1101,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
         )
     }
 
-    private fun buildGenresItems(): MutableList<MediaItem> {
+    private fun buildGenresItems(): List<MediaItem> {
         ensureMetadataIndexes()
         return buildCategoryListItems(
             mediaCacheService.genres(),
@@ -1111,7 +1111,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
         )
     }
 
-    private fun buildArtistsItems(): MutableList<MediaItem> {
+    private fun buildArtistsItems(): List<MediaItem> {
         ensureMetadataIndexes()
         return buildCategoryListItems(
             buildLetterBuckets(mediaCacheService.artists()),
@@ -1120,7 +1120,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
         )
     }
 
-    private fun buildDecadesItems(): MutableList<MediaItem> {
+    private fun buildDecadesItems(): List<MediaItem> {
         ensureMetadataIndexes()
         return buildCategoryListItems(
             mediaCacheService.decades(),
@@ -1130,7 +1130,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
         )
     }
 
-    private fun buildSearchItems(): MutableList<MediaItem> {
+    private fun buildSearchItems(): List<MediaItem> {
         return mutableListOf(
             MediaItem(
                 MediaDescriptionCompat.Builder()
@@ -1141,7 +1141,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
             )
         )
     }
-    internal fun buildMediaItems(parentId: String): MutableList<MediaItem> {
+    internal fun buildMediaItems(parentId: String): List<MediaItem> {
         val start = SystemClock.elapsedRealtime()
 
         val prefixItems = buildMediaItemsForPrefix(parentId)
@@ -1313,7 +1313,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
         }.eachCount()
     }
 
-    private fun buildPlayAllShuffleItems(listKey: String): MutableList<MediaItem> {
+    private fun buildPlayAllShuffleItems(listKey: String): List<MediaItem> {
         val items = mutableListOf<MediaItem>()
         items.add(
             MediaItem(
@@ -2933,7 +2933,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
         }
     }
 
-    internal fun buildHomeItems(): MutableList<MediaItem> {
+    internal fun buildHomeItems(): List<MediaItem> {
         val items = mutableListOf<MediaItem>()
         val childListExtras = Bundle().apply {
             putInt(

--- a/shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
@@ -887,7 +887,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
 
     private fun buildMediaItemsForPlaylist(parentId: String): List<MediaItem> {
             val shortId = parentId.removePrefix(PLAYLIST_PREFIX)
-            val playlistUri = playlistShortIds[shortId] ?: return mutableListOf()
+            val playlistUri = playlistShortIds[shortId] ?: return emptyList()
             val songs = enrichFromCache(
                 playlistService.readPlaylist(this, Uri.parse(playlistUri))
             )
@@ -917,7 +917,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
 
     private fun buildMediaItemsForGenreSongLetter(parentId: String): List<MediaItem> {
             ensureMetadataIndexes()
-            val parts = parseBucketParts(parentId, GENRE_SONG_LETTER_PREFIX) ?: return mutableListOf()
+            val parts = parseBucketParts(parentId, GENRE_SONG_LETTER_PREFIX) ?: return emptyList()
             val genre = parts.first
             val letter = parts.second
             val songs = mediaCacheService.songsForGenre(genre)
@@ -961,7 +961,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
 
     private fun buildMediaItemsForDecadeSongLetter(parentId: String): List<MediaItem> {
             ensureMetadataIndexes()
-            val parts = parseBucketParts(parentId, DECADE_SONG_LETTER_PREFIX) ?: return mutableListOf()
+            val parts = parseBucketParts(parentId, DECADE_SONG_LETTER_PREFIX) ?: return emptyList()
             val decade = parts.first
             val letter = parts.second
             val songs = mediaCacheService.songsForDecade(decade)
@@ -1340,24 +1340,21 @@ class MyMusicService : MediaBrowserServiceCompat() {
         songs: List<MediaFileInfo>,
         listKey: String,
         bucketPrefix: String
-    ): MutableList<MediaItem> {
-        val items = buildPlayAllShuffleItems(listKey)
-        items += buildCategoryListItems(
+    ): List<MediaItem> {
+        return buildPlayAllShuffleItems(listKey) + buildCategoryListItems(
             buildSongLetterBuckets(songs),
             bucketPrefix,
             buildSongLetterCounts(songs),
             resourceIconUri(R.drawable.ic_auto_song)
         )
-        return items
     }
 
     private fun buildSongLetterItems(
         listKey: String,
         songs: List<MediaFileInfo>
-    ): MutableList<MediaItem> {
-        val items = buildPlayAllShuffleItems(listKey)
-        items += buildSongItems(songs, resourceIconUri(R.drawable.ic_album_placeholder))
-        return items
+    ): List<MediaItem> {
+        return buildPlayAllShuffleItems(listKey) +
+            buildSongItems(songs, resourceIconUri(R.drawable.ic_album_placeholder))
     }
 
     @VisibleForTesting


### PR DESCRIPTION
Updates the Android Auto media item builder helpers to expose read-only `List<MediaItem>` results where callers only need to read or pass through the collections. This removes unnecessary mutable return contracts and avoids a couple of redundant mutable-list conversions while keeping the service callback boundaries that require `MutableList` unchanged. Closes #249.

Verification: `git diff --check` passed. `./gradlew :shared:compileDebugKotlin --no-daemon -Dorg.gradle.java.home=/usr/lib/jvm/java-21-openjdk-amd64` could not run locally because this environment does not have an Android SDK configured (`ANDROID_HOME` / `local.properties` missing).
