### PR TITLE
feat: separate Podcasts category (#252)

### DIFF
--- a/docs/superpowers/specs/2026-05-16-podcast-category-design.md
+++ b/docs/superpowers/specs/2026-05-16-podcast-category-design.md
@@ -10,8 +10,10 @@ Treat podcast-like media files as a distinct category. They appear in **Genres â
 
 A file is classified as a podcast when **any** of the following match:
 
-1. Its raw genre tag contains (case-insensitive) `podcast`, `audiobook`, or `spoken`.
+1. Its raw genre tag contains (case-insensitive) `podcast`, `audiobook`, or `spoken word`.
 2. Its folder path or URI contains (case-insensitive) `podcast`.
+
+The space in `spoken word` matters â€” matching bare `spoken` would catch unrelated words like `Unspoken` or `Outspoken`. `Spoken Word` is also the ID3 v2 genre name (180), so the phrase match aligns with what tagged files actually carry.
 
 Implementation: new top-level function in `shared/`:
 
@@ -19,7 +21,7 @@ Implementation: new top-level function in `shared/`:
 // shared/src/main/java/com/example/mymediaplayer/shared/PodcastDetection.kt
 fun isPodcastMedia(rawGenre: String?, pathOrUri: String?): Boolean {
     val g = rawGenre.orEmpty().lowercase(Locale.US)
-    if (g.contains("podcast") || g.contains("audiobook") || g.contains("spoken")) return true
+    if (g.contains("podcast") || g.contains("audiobook") || g.contains("spoken word")) return true
     val p = pathOrUri.orEmpty().lowercase(Locale.US)
     return p.contains("podcast")
 }

--- a/docs/superpowers/specs/2026-05-16-podcast-category-design.md
+++ b/docs/superpowers/specs/2026-05-16-podcast-category-design.md
@@ -1,0 +1,146 @@
+# Podcasts as a separate category — design
+
+GitHub issue: [#252](https://github.com/kimptoc/MyMediaPlayer/issues/252)
+
+## Goal
+
+Treat podcast-like media files as a distinct category. They appear in **Genres → Podcasts** and in **search results**, but are excluded from **All Songs**, **Albums**, **Artists**, **Decades**, and all non-Podcasts genre buckets.
+
+## Detection
+
+A file is classified as a podcast when **any** of the following match:
+
+1. Its raw genre tag contains (case-insensitive) `podcast`, `audiobook`, or `spoken`.
+2. Its folder path or URI contains (case-insensitive) `podcast`.
+
+Implementation: new top-level function in `shared/`:
+
+```kotlin
+// shared/src/main/java/com/example/mymediaplayer/shared/PodcastDetection.kt
+fun isPodcastMedia(rawGenre: String?, pathOrUri: String?): Boolean {
+    val g = rawGenre.orEmpty().lowercase(Locale.US)
+    if (g.contains("podcast") || g.contains("audiobook") || g.contains("spoken")) return true
+    val p = pathOrUri.orEmpty().lowercase(Locale.US)
+    return p.contains("podcast")
+}
+```
+
+A shared constant `const val PODCAST_GENRE = "Podcasts"` lives in `GenreBuckets.kt` next to `bucketGenre`.
+
+## Data model
+
+`MediaFileInfo` gains:
+
+```kotlin
+val isPodcast: Boolean = false
+```
+
+The field is **not persisted** to Room. It is derived from `genre` + `uriString` at every entry point that creates or revives a `MediaFileInfo`. No DB migration.
+
+Entry points that compute `isPodcast`:
+
+- `MediaCacheService.extractCandidateMetadata()` — uses `metadata?.genre` and `candidate.parentFolderName`.
+- The MediaStore scan branch around `MediaCacheService.kt:173` — uses `osGenre` and `relativePath`.
+- `MediaCacheService.loadPersistedCache()` — uses `it.genre` and `Uri.decode(it.uriString)`.
+
+## Index building
+
+`MediaCacheService.buildAlbumArtistIndexesFromCache()` routes podcasts away from album/artist/decade indexes and into a single `Podcasts` genre bucket:
+
+```kotlin
+for (file in snapshot) {
+    if (file.isPodcast) {
+        genreIndex.getOrPut(PODCAST_GENRE) { mutableListOf() }.add(file)
+    } else {
+        val album  = file.album?.ifBlank { null } ?: "Unknown Album"
+        val artist = file.artist?.ifBlank { null } ?: "Unknown Artist"
+        val genre  = bucketGenre(file.genre)
+        val decade = decadeLabel(file.year)
+        albumIndex.getOrPut(album)  { mutableListOf() }.add(file)
+        artistIndex.getOrPut(artist){ mutableListOf() }.add(file)
+        genreIndex.getOrPut(genre)  { mutableListOf() }.add(file)
+        decadeIndex.getOrPut(decade){ mutableListOf() }.add(file)
+    }
+}
+```
+
+## New accessor
+
+```kotlin
+val cachedMusicFiles: List<MediaFileInfo>
+    get() = synchronized(cacheLock) { _cachedFiles.filter { !it.isPodcast } }
+```
+
+`cachedFiles` is unchanged (still all files; required by search, persistence, and URI lookup).
+
+## Callsite audit — `MyMusicService`
+
+**Switch from `cachedFiles` to `cachedMusicFiles`** (exclude podcasts):
+
+| Line | Use |
+|------|-----|
+| 918  | `buildArtistCounts` argument |
+| 962  | letter-filter for songs browse |
+| 1016 | empty check before adding the All-Songs row |
+| 1050 | `buildSongsAllItems` titles → letter buckets |
+| 1074 | `buildAlbumCounts` argument |
+| 1103 | `buildDecadeCounts` argument |
+| 2016 | songs list for `SONGS_ID` |
+| 2054 | letter filter on the music side |
+| 2188 | fallback queue source |
+| 2215, 2216 | queue building for `SONGS_ID` / `SONGS_ALL_ID` |
+| 2239 | fallback letter filter |
+| 2471 | empty check |
+| 2514 | smart-playlist source (favorites / recently-added / most-played / flagged) |
+| 2923 | home-screen `songCount` |
+
+**Keep `cachedFiles`** (need every file, including podcasts):
+
+| Line | Use |
+|------|-----|
+| 663  | URI lookup for `playProvidedUriList` |
+| 2168 | first-by-URI lookup |
+| 2323 | free-text search — podcasts ARE findable in search |
+| 2410, 2445, 2448, 2451, 2454 | voice-search filters — voice search is a query, same logic as text search |
+| 635, 775 | log/diagnostic counters only |
+
+**`buildGenreCounts` (L1256) — small special-case:** route `isPodcast` files to the `PODCAST_GENRE` key instead of `bucketGenre(file.genre)`. Continue to pass `cachedFiles` (all) so podcasts contribute to the Podcasts count.
+
+```kotlin
+private fun buildGenreCounts(files: List<MediaFileInfo>): Map<String, Int> =
+    files.groupingBy { file ->
+        if (file.isPodcast) PODCAST_GENRE else bucketGenre(file.genre)
+    }.eachCount()
+```
+
+## Search behaviour
+
+`searchFiles(query)` in `MediaCacheService` is unchanged — it iterates `_cachedFiles`, so podcasts remain searchable. Voice search filters in `MyMusicService` also keep using `cachedFiles`.
+
+## Tests
+
+1. **`PodcastDetectionTest.kt`** (new, JVM unit) — table-driven cases for `isPodcastMedia`:
+   - Tagged genres: `"Podcast"`, `"podcast"`, `"Audiobook"`, `"Spoken Word"`, `"Podcast;News"` → true.
+   - Path matches: `"/storage/Podcasts/show.mp3"`, `"file://.../podcast-feeds/ep.mp3"` → true.
+   - Plain music: `"Rock"` + `"/Music/AC-DC/..."` → false.
+   - Null and empty inputs → false.
+
+2. **`MediaCacheServicePodcastIndexTest.kt`** (new, JVM unit) — populate `_cachedFiles` with a mix of music + podcast files, call `buildAlbumArtistIndexesFromCache()`, assert:
+   - `genres()` contains `"Podcasts"`.
+   - `songsForGenre("Podcasts")` contains exactly the podcast files.
+   - Podcast files are absent from `albums()`, `artists()`, `decades()`, and from every non-Podcasts `songsForGenre(...)`.
+   - Music files are indexed normally.
+
+3. **`MyMusicServiceGenreCountsTest.kt`** (new, JVM unit) — focused test for the updated `buildGenreCounts`, asserting podcasts count toward `"Podcasts"` and not `"Other"`.
+
+No automated coverage planned for the wide `cachedFiles` → `cachedMusicFiles` swap in `MyMusicService` — those are mechanical refactors. Verification is via build + manual smoke:
+
+- Genres list shows a `Podcasts` entry; tapping it lists the podcast files.
+- All Songs, Albums, Artists, Decades omit podcast files.
+- Search finds podcasts.
+
+## Out of scope
+
+- Podcast-specific UI affordances (episode ordering, playback resume per episode).
+- A top-level `Podcasts` browse node alongside Songs/Albums/Artists.
+- Migration of the persisted Room cache (no schema change needed).

--- a/shared/src/main/java/com/example/mymediaplayer/shared/GenreBuckets.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/GenreBuckets.kt
@@ -2,6 +2,8 @@ package com.example.mymediaplayer.shared
 
 import java.util.Locale
 
+const val PODCAST_GENRE: String = "Podcasts"
+
 fun bucketGenre(raw: String?): String {
     val trimmed = raw?.trim().orEmpty()
     if (trimmed.isBlank()) return "Other"

--- a/shared/src/main/java/com/example/mymediaplayer/shared/MediaCacheService.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/MediaCacheService.kt
@@ -173,7 +173,8 @@ class MediaCacheService {
                         genre = normalizeGenre(osGenre ?: inferGenreFromPath(relativePath)),
                         durationMs = durationMs,
                         year = year,
-                        addedAtMs = addedAtMs
+                        addedAtMs = addedAtMs,
+                        isPodcast = isPodcastMedia(osGenre, relativePath)
                     )
                 )
                 outIds.add(id)
@@ -199,7 +200,12 @@ class MediaCacheService {
                 val audioId = outIds[index]
                 val mappedGenre = genresByAudioId[audioId] ?: continue
                 val normalized = genreCache.getOrPut(mappedGenre) { normalizeGenre(mappedGenre) }
-                out[index] = out[index].copy(genre = normalized)
+                val existing = out[index]
+                out[index] = existing.copy(
+                    genre = normalized,
+                    isPodcast = existing.isPodcast ||
+                        isPodcastMedia(mappedGenre, existing.uriString)
+                )
             }
         }
     }
@@ -292,11 +298,13 @@ class MediaCacheService {
         val genresByAudioId = loadWholeDriveGenres(context, audioIdByName.values.toSet())
         if (genresByAudioId.isEmpty()) return
 
-        // Pre-compute the displayName -> normalizedGenre mapping outside the lock
-        val genreUpdates = mutableMapOf<String, String>()
+        // Pre-compute the displayName -> (normalizedGenre, rawGenre) mapping outside the lock.
+        // Raw genre is retained so podcast detection can still see "Podcast" / "Audiobook" /
+        // "Spoken Word" before normalization collapses it.
+        val genreUpdates = mutableMapOf<String, Pair<String, String>>()
         for ((name, audioId) in audioIdByName) {
             val genre = genresByAudioId[audioId] ?: continue
-            genreUpdates[name] = normalizeGenre(genre)
+            genreUpdates[name] = normalizeGenre(genre) to genre
         }
 
         if (genreUpdates.isEmpty()) return
@@ -305,8 +313,13 @@ class MediaCacheService {
             for (i in _cachedFiles.indices) {
                 val file = _cachedFiles[i]
                 if (!file.genre.isNullOrBlank()) continue // prefer ID3 tag genre
-                val newGenre = genreUpdates[file.displayName] ?: continue
-                _cachedFiles[i] = file.copy(genre = newGenre)
+                val update = genreUpdates[file.displayName] ?: continue
+                val (newGenre, rawGenre) = update
+                _cachedFiles[i] = file.copy(
+                    genre = newGenre,
+                    isPodcast = file.isPodcast ||
+                        isPodcastMedia(rawGenre, file.uriString)
+                )
                 _cachedFilesByUri[file.uriString] = _cachedFiles[i]
             }
         }
@@ -315,6 +328,8 @@ class MediaCacheService {
     private val _cachedFiles = mutableListOf<MediaFileInfo>()
     val cachedFiles: List<MediaFileInfo>
         get() = synchronized(cacheLock) { _cachedFiles.toList() }
+    val cachedMusicFiles: List<MediaFileInfo>
+        get() = synchronized(cacheLock) { _cachedFiles.filter { !it.isPodcast } }
 
     private val _cachedFilesByUri = mutableMapOf<String, MediaFileInfo>()
     fun getFileIndexByUri(): Map<String, MediaFileInfo> = synchronized(cacheLock) { _cachedFilesByUri.toMap() }
@@ -454,7 +469,11 @@ class MediaCacheService {
             ),
             durationMs = durationMs,
             year = yearValue,
-            addedAtMs = candidate.lastModified
+            addedAtMs = candidate.lastModified,
+            isPodcast = isPodcastMedia(
+                metadata?.genre,
+                candidate.parentFolderName ?: candidate.uri.toString()
+            )
         )
     }
 
@@ -470,9 +489,8 @@ class MediaCacheService {
             return null
         }
         val files = dao.getAllFiles().map {
-            val genre = it.genre ?: normalizeGenre(
-                inferGenreFromPath(Uri.decode(it.uriString))
-            )
+            val decodedUri = Uri.decode(it.uriString)
+            val genre = it.genre ?: normalizeGenre(inferGenreFromPath(decodedUri))
             MediaFileInfo(
                 uriString = it.uriString,
                 displayName = it.displayName,
@@ -483,7 +501,8 @@ class MediaCacheService {
                 genre = genre,
                 durationMs = it.durationMs,
                 year = it.year,
-                addedAtMs = it.addedAtMs
+                addedAtMs = it.addedAtMs,
+                isPodcast = isPodcastMedia(it.genre, decodedUri)
             )
         }
         val playlists = dao.getAllPlaylists().map {
@@ -796,6 +815,10 @@ class MediaCacheService {
         clearMetadataIndexes()
         val snapshot = synchronized(cacheLock) { _cachedFiles.toList() }
         for (file in snapshot) {
+            if (file.isPodcast) {
+                genreIndex.getOrPut(PODCAST_GENRE) { mutableListOf() }.add(file)
+                continue
+            }
             val album = file.album?.ifBlank { null } ?: "Unknown Album"
             val artist = file.artist?.ifBlank { null } ?: "Unknown Artist"
             val genre = bucketGenre(file.genre)

--- a/shared/src/main/java/com/example/mymediaplayer/shared/MediaFileInfo.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/MediaFileInfo.kt
@@ -10,7 +10,8 @@ data class MediaFileInfo(
     val genre: String? = null,
     val durationMs: Long? = null,
     val year: Int? = null,
-    val addedAtMs: Long? = null
+    val addedAtMs: Long? = null,
+    val isPodcast: Boolean = false
 ) {
     val cleanTitle: String
         get() = title?.takeIf { it.isNotBlank() }

--- a/shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
@@ -915,7 +915,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
             return buildCategoryListItems(
                 filterByLetter(mediaCacheService.artists(), letter),
                 ARTIST_PREFIX,
-                buildArtistCounts(mediaCacheService.cachedFiles),
+                buildArtistCounts(mediaCacheService.cachedMusicFiles),
                 resourceIconUri(R.drawable.ic_auto_artists)
             )
     }
@@ -959,7 +959,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
 
     private fun buildMediaItemsForSongLetter(parentId: String): MutableList<MediaItem> {
             val letter = Uri.decode(parentId.removePrefix(SONG_LETTER_PREFIX))
-            val filtered = filterSongsByLetter(mediaCacheService.cachedFiles, letter)
+            val filtered = filterSongsByLetter(mediaCacheService.cachedMusicFiles, letter)
             return buildSongLetterItems(
                 SONG_LETTER_PREFIX + Uri.encode(letter),
                 filtered
@@ -1013,7 +1013,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
 
     private fun buildSongsItems(): MutableList<MediaItem> {
         val items = mutableListOf<MediaItem>()
-        if (mediaCacheService.cachedFiles.isNotEmpty()) {
+        if (mediaCacheService.cachedMusicFiles.isNotEmpty()) {
             items.add(
                 MediaItem(
                     MediaDescriptionCompat.Builder()
@@ -1047,7 +1047,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
     }
 
     private fun buildSongsAllItems(): MutableList<MediaItem> {
-        val titles = mediaCacheService.cachedFiles.map { it.cleanTitle }
+        val titles = mediaCacheService.cachedMusicFiles.map { it.cleanTitle }
         return buildCategoryListItems(
             buildLetterBuckets(titles),
             SONG_LETTER_PREFIX,
@@ -1071,7 +1071,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
         return buildCategoryListItems(
             mediaCacheService.albums(),
             ALBUM_PREFIX,
-            buildAlbumCounts(mediaCacheService.cachedFiles),
+            buildAlbumCounts(mediaCacheService.cachedMusicFiles),
             resourceIconUri(R.drawable.ic_auto_albums)
         )
     }
@@ -1100,7 +1100,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
         return buildCategoryListItems(
             mediaCacheService.decades(),
             DECADE_PREFIX,
-            buildDecadeCounts(mediaCacheService.cachedFiles),
+            buildDecadeCounts(mediaCacheService.cachedMusicFiles),
             resourceIconUri(R.drawable.ic_auto_decades)
         )
     }
@@ -1255,7 +1255,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
 
     private fun buildGenreCounts(files: List<MediaFileInfo>): Map<String, Int> =
         files.groupingBy { file ->
-            bucketGenre(file.genre)
+            if (file.isPodcast) PODCAST_GENRE else bucketGenre(file.genre)
         }.eachCount()
 
     @VisibleForTesting
@@ -2013,7 +2013,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
 
     private suspend fun resolveTracksForListKey(listKey: String): List<MediaFileInfo> {
         return when {
-            listKey == SONGS_ID -> mediaCacheService.cachedFiles
+            listKey == SONGS_ID -> mediaCacheService.cachedMusicFiles
             listKey.startsWith(PLAYLIST_SHORT_PREFIX) -> {
                 val shortId = listKey.removePrefix(PLAYLIST_SHORT_PREFIX)
                 val playlistUri = playlistShortIds[shortId] ?: ""
@@ -2051,7 +2051,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
             }
             listKey.startsWith(SONG_LETTER_PREFIX) -> {
                 val letter = Uri.decode(listKey.removePrefix(SONG_LETTER_PREFIX))
-                filterSongsByLetter(mediaCacheService.cachedFiles, letter)
+                filterSongsByLetter(mediaCacheService.cachedMusicFiles, letter)
             }
             listKey.startsWith(GENRE_SONG_LETTER_PREFIX) -> {
                 ensureMetadataIndexes()
@@ -2185,7 +2185,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
         val parentList = when {
             listFromParent.isNotEmpty() -> listFromParent
             searchList.isNotEmpty() -> searchList
-            mediaCacheService.cachedFiles.isNotEmpty() -> mediaCacheService.cachedFiles
+            mediaCacheService.cachedMusicFiles.isNotEmpty() -> mediaCacheService.cachedMusicFiles
             else -> emptyList()
         }
 
@@ -2212,8 +2212,8 @@ class MyMusicService : MediaBrowserServiceCompat() {
 
     private fun getListFromParent(parentId: String?): List<MediaFileInfo> {
         return when {
-            parentId == SONGS_ID -> mediaCacheService.cachedFiles
-            parentId == SONGS_ALL_ID -> mediaCacheService.cachedFiles
+            parentId == SONGS_ID -> mediaCacheService.cachedMusicFiles
+            parentId == SONGS_ALL_ID -> mediaCacheService.cachedMusicFiles
             parentId != null && parentId.startsWith(ALBUM_PREFIX) -> {
                 ensureMetadataIndexes()
                 val album = Uri.decode(parentId.removePrefix(ALBUM_PREFIX))
@@ -2236,7 +2236,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
             }
             parentId != null && parentId.startsWith(SONG_LETTER_PREFIX) -> {
                 val letter = Uri.decode(parentId.removePrefix(SONG_LETTER_PREFIX))
-                filterSongsByLetter(mediaCacheService.cachedFiles, letter)
+                filterSongsByLetter(mediaCacheService.cachedMusicFiles, letter)
             }
             parentId != null && parentId.startsWith(GENRE_SONG_LETTER_PREFIX) -> {
                 ensureMetadataIndexes()
@@ -2511,7 +2511,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
     }
 
     private fun resolveSmartPlaylistTracksById(smartId: String): List<MediaFileInfo>? {
-        val all = mediaCacheService.cachedFiles.ifEmpty { playlistQueue }
+        val all = mediaCacheService.cachedMusicFiles.ifEmpty { playlistQueue }
         if (all.isEmpty()) return null
         return when (smartId) {
             SMART_PLAYLIST_FAVORITES -> {
@@ -2920,7 +2920,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
             )
         }
         val playlistCount = mediaCacheService.discoveredPlaylists.size
-        val songCount = mediaCacheService.cachedFiles.size
+        val songCount = mediaCacheService.cachedMusicFiles.size
         if (playlistCount > 0 || songCount > 0) {
             val playlistSubtitle = if (playlistCount > 0)
                 "$playlistCount playlist${if (playlistCount != 1) "s" else ""}"

--- a/shared/src/main/java/com/example/mymediaplayer/shared/PodcastDetection.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/PodcastDetection.kt
@@ -1,0 +1,12 @@
+package com.example.mymediaplayer.shared
+
+import java.util.Locale
+
+fun isPodcastMedia(rawGenre: String?, pathOrUri: String?): Boolean {
+    val genre = rawGenre.orEmpty().lowercase(Locale.US)
+    if (genre.contains("podcast") || genre.contains("audiobook") || genre.contains("spoken")) {
+        return true
+    }
+    val path = pathOrUri.orEmpty().lowercase(Locale.US)
+    return path.contains("podcast")
+}

--- a/shared/src/main/java/com/example/mymediaplayer/shared/PodcastDetection.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/PodcastDetection.kt
@@ -4,7 +4,7 @@ import java.util.Locale
 
 fun isPodcastMedia(rawGenre: String?, pathOrUri: String?): Boolean {
     val genre = rawGenre.orEmpty().lowercase(Locale.US)
-    if (genre.contains("podcast") || genre.contains("audiobook") || genre.contains("spoken")) {
+    if (genre.contains("podcast") || genre.contains("audiobook") || genre.contains("spoken word")) {
         return true
     }
     val path = pathOrUri.orEmpty().lowercase(Locale.US)

--- a/shared/src/test/java/com/example/mymediaplayer/shared/MediaCacheServicePodcastIndexTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/MediaCacheServicePodcastIndexTest.kt
@@ -1,0 +1,109 @@
+package com.example.mymediaplayer.shared
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MediaCacheServicePodcastIndexTest {
+
+    private fun mediaFile(
+        uri: String,
+        title: String,
+        artist: String?,
+        album: String?,
+        genre: String?,
+        year: Int?,
+        isPodcast: Boolean
+    ) = MediaFileInfo(
+        uriString = uri,
+        displayName = "$title.mp3",
+        sizeBytes = 1L,
+        title = title,
+        artist = artist,
+        album = album,
+        genre = genre,
+        durationMs = 1000L,
+        year = year,
+        isPodcast = isPodcast
+    )
+
+    @Test
+    fun podcastsLandOnlyInPodcastsGenre() {
+        val service = MediaCacheService()
+        val music = mediaFile(
+            uri = "file:///Music/AC-DC/Highway.mp3",
+            title = "Highway",
+            artist = "AC/DC",
+            album = "Highway to Hell",
+            genre = "Rock",
+            year = 1979,
+            isPodcast = false
+        )
+        val podcast = mediaFile(
+            uri = "file:///Podcasts/show/ep1.mp3",
+            title = "Ep1",
+            artist = "Host",
+            album = "Show",
+            genre = "Podcast",
+            year = 2024,
+            isPodcast = true
+        )
+        service.addAllFiles(listOf(music, podcast))
+
+        service.buildAlbumArtistIndexesFromCache()
+
+        assertTrue("Podcasts genre present", service.genres().contains(PODCAST_GENRE))
+        assertEquals(listOf(podcast), service.songsForGenre(PODCAST_GENRE))
+
+        assertFalse("podcast album hidden", service.albums().contains("Show"))
+        assertFalse("podcast artist hidden", service.artists().contains("Host"))
+        assertFalse(
+            "podcast decade hidden",
+            service.decades().contains("2020s") &&
+                service.songsForDecade("2020s").any { it.uriString == podcast.uriString }
+        )
+        for (g in service.genres()) {
+            if (g == PODCAST_GENRE) continue
+            assertTrue(
+                "non-podcast genre '$g' contains a podcast",
+                service.songsForGenre(g).none { it.isPodcast }
+            )
+        }
+
+        assertTrue("music album indexed", service.albums().contains("Highway to Hell"))
+        assertTrue("music artist indexed", service.artists().contains("AC/DC"))
+        assertTrue("music decade indexed", service.decades().contains("1970s"))
+        assertTrue(
+            "music in rock genre",
+            service.songsForGenre("Rock/Metal").any { it.uriString == music.uriString }
+        )
+    }
+
+    @Test
+    fun cachedMusicFilesExcludesPodcasts() {
+        val service = MediaCacheService()
+        val music = mediaFile(
+            uri = "file:///Music/song.mp3",
+            title = "song",
+            artist = "A",
+            album = "Al",
+            genre = "Rock",
+            year = 2000,
+            isPodcast = false
+        )
+        val podcast = mediaFile(
+            uri = "file:///Podcasts/ep.mp3",
+            title = "ep",
+            artist = "H",
+            album = "S",
+            genre = "Podcast",
+            year = 2024,
+            isPodcast = true
+        )
+        service.addAllFiles(listOf(music, podcast))
+
+        assertEquals(listOf(music), service.cachedMusicFiles)
+        assertEquals(2, service.cachedFiles.size)
+    }
+}

--- a/shared/src/test/java/com/example/mymediaplayer/shared/MyMusicServiceGenreCountsTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/MyMusicServiceGenreCountsTest.kt
@@ -38,7 +38,7 @@ class MyMusicServiceGenreCountsTest {
         val counts = method.invoke(service, files) as Map<String, Int>
 
         assertEquals(3, counts[PODCAST_GENRE])
-        assertEquals(1, counts["Rock/Metal"])
-        assertEquals(1, counts["Hip-Hop/Rap"])
+        assertEquals(1, counts[bucketGenre("Rock")])
+        assertEquals(1, counts[bucketGenre("Hip-Hop")])
     }
 }

--- a/shared/src/test/java/com/example/mymediaplayer/shared/MyMusicServiceGenreCountsTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/MyMusicServiceGenreCountsTest.kt
@@ -1,0 +1,44 @@
+package com.example.mymediaplayer.shared
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class MyMusicServiceGenreCountsTest {
+
+    private fun mediaFile(genre: String?, isPodcast: Boolean) = MediaFileInfo(
+        uriString = "file:///${if (isPodcast) "podcast" else "song"}-${genre.orEmpty()}",
+        displayName = "x.mp3",
+        sizeBytes = 1L,
+        title = "x",
+        genre = genre,
+        isPodcast = isPodcast
+    )
+
+    @Test
+    fun podcastsCountUnderPodcastsBucket() {
+        val service = MyMusicService()
+        val method = MyMusicService::class.java.getDeclaredMethod(
+            "buildGenreCounts",
+            List::class.java
+        )
+        method.isAccessible = true
+
+        val files = listOf(
+            mediaFile("Rock", isPodcast = false),
+            mediaFile("Hip-Hop", isPodcast = false),
+            mediaFile("Podcast", isPodcast = true),
+            mediaFile("Audiobook", isPodcast = true),
+            mediaFile("Spoken Word", isPodcast = true)
+        )
+
+        @Suppress("UNCHECKED_CAST")
+        val counts = method.invoke(service, files) as Map<String, Int>
+
+        assertEquals(3, counts[PODCAST_GENRE])
+        assertEquals(1, counts["Rock/Metal"])
+        assertEquals(1, counts["Hip-Hop/Rap"])
+    }
+}

--- a/shared/src/test/java/com/example/mymediaplayer/shared/PodcastDetectionTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/PodcastDetectionTest.kt
@@ -1,0 +1,39 @@
+package com.example.mymediaplayer.shared
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PodcastDetectionTest {
+
+    @Test
+    fun genreTagsDetectPodcasts() {
+        assertTrue(isPodcastMedia("Podcast", "/Music/Show/ep1.mp3"))
+        assertTrue(isPodcastMedia("podcast", null))
+        assertTrue(isPodcastMedia("Audiobook", null))
+        assertTrue(isPodcastMedia("Spoken Word", null))
+        assertTrue(isPodcastMedia("News;Podcast", null))
+    }
+
+    @Test
+    fun pathDetectsPodcasts() {
+        assertTrue(isPodcastMedia(null, "/storage/Podcasts/show.mp3"))
+        assertTrue(isPodcastMedia("Rock", "/storage/Podcasts/show.mp3"))
+        assertTrue(isPodcastMedia(null, "content://.../podcast-feeds/ep.mp3"))
+    }
+
+    @Test
+    fun musicFilesAreNotPodcasts() {
+        assertFalse(isPodcastMedia("Rock", "/Music/AC-DC/Highway.mp3"))
+        assertFalse(isPodcastMedia("Jazz", null))
+        assertFalse(isPodcastMedia(null, "/Music/Artist/Album/song.mp3"))
+    }
+
+    @Test
+    fun emptyAndNullInputsAreNotPodcasts() {
+        assertFalse(isPodcastMedia(null, null))
+        assertFalse(isPodcastMedia("", ""))
+        assertFalse(isPodcastMedia("", null))
+        assertFalse(isPodcastMedia(null, ""))
+    }
+}

--- a/shared/src/test/java/com/example/mymediaplayer/shared/PodcastDetectionTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/PodcastDetectionTest.kt
@@ -16,6 +16,12 @@ class PodcastDetectionTest {
     }
 
     @Test
+    fun spokenSubstringDoesNotMatchUnrelatedWords() {
+        assertFalse(isPodcastMedia("Unspoken", null))
+        assertFalse(isPodcastMedia("Outspoken", null))
+    }
+
+    @Test
     fun pathDetectsPodcasts() {
         assertTrue(isPodcastMedia(null, "/storage/Podcasts/show.mp3"))
         assertTrue(isPodcastMedia("Rock", "/storage/Podcasts/show.mp3"))


### PR DESCRIPTION
Closes #252.

## Summary
- Detect podcasts when the raw genre contains `podcast`/`audiobook`/`spoken`, or the file path contains `podcast`.
- Route podcasts to **Genres → Podcasts** only; exclude them from All Songs, Albums, Artists, Decades, and all other genre buckets.
- Keep podcasts findable in text and voice search.
- `isPodcast` is derived from `genre` + `uriString` and recomputed at every entry point (SAF scan, MediaStore scan, persisted-cache load, and both legacy-genre enrichment passes) — no Room schema migration needed.

Design spec: [`docs/superpowers/specs/2026-05-16-podcast-category-design.md`](https://github.com/kimptoc/MyMediaPlayer/blob/feat/podcast-category-252/docs/superpowers/specs/2026-05-16-podcast-category-design.md).

## Test plan
- [x] `:shared:testDebugUnitTest` — new tests: `PodcastDetectionTest` (4), `MediaCacheServicePodcastIndexTest` (2), `MyMusicServiceGenreCountsTest` (1) all pass; existing tests still green.
- [x] `:mobile:testDebugUnitTest` passes.
- [x] `./gradlew assembleDebug` passes (mobile + automotive variants).
- [ ] Manual smoke on phone: Genres list shows `Podcasts`; tapping it lists podcast files. All Songs, Albums, Artists, Decades omit podcasts. Search finds podcasts.
- [ ] Manual smoke on Android Auto / DHU: same browse expectations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)