### PR TITLE
🧹 [code health improvement] Remove unused VisibleForTesting import in MainScreenKtTest

### DIFF
--- a/mobile/src/test/java/com/example/mymediaplayer/MainScreenKtTest.kt
+++ b/mobile/src/test/java/com/example/mymediaplayer/MainScreenKtTest.kt
@@ -2,7 +2,6 @@ package com.example.mymediaplayer
 
 import org.junit.Assert.assertEquals
 import org.junit.Test
-import androidx.annotation.VisibleForTesting
 
 class MainScreenKtTest {
 


### PR DESCRIPTION
🎯 **What:** Removed the unused `androidx.annotation.VisibleForTesting` import from `mobile/src/test/java/com/example/mymediaplayer/MainScreenKtTest.kt`.
💡 **Why:** To improve code health and cleanliness. Unused imports clutter the codebase and can sometimes cause confusion.
✅ **Verification:** Ran `./gradlew :mobile:testDebugUnitTest` to ensure all tests still pass and no regressions were introduced.
✨ **Result:** A cleaner test file without unnecessary imports.

---
*PR created automatically by Jules for task [9817582534378860214](https://jules.google.com/task/9817582534378860214) started by @kimptoc*