### PR TITLE
🔒 Fix insecure backup configuration

### DIFF
--- a/automotive/src/main/AndroidManifest.xml
+++ b/automotive/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:appCategory="audio"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
     <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is an insecure backup configuration. `android:allowBackup="true"` was explicitly set in the application manifests, allowing application data to be extracted via `adb backup`.
⚠️ **Risk:** If left unfixed, an attacker with physical access to the device (or ADB access) could extract sensitive application data, including shared preferences, databases, and cached files that are otherwise inaccessible, putting user data at risk.
🛡️ **Solution:** The fix addresses the vulnerability by setting `android:allowBackup="false"` in the application tag in both `mobile/src/main/AndroidManifest.xml` and `automotive/src/main/AndroidManifest.xml`, effectively disabling the ability to perform adb backups and securing the app's standard data directories.

---
*PR created automatically by Jules for task [3767791999287889448](https://jules.google.com/task/3767791999287889448) started by @kimptoc*