### PR TITLE
🧪 [Testing Improvement] Add tests for MediaFileInfo.cleanTitle

### DIFF
--- a/shared/src/test/java/com/example/mymediaplayer/shared/MediaFileInfoTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/MediaFileInfoTest.kt
@@ -1,0 +1,51 @@
+package com.example.mymediaplayer.shared
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MediaFileInfoTest {
+
+    @Test
+    fun cleanTitle_hasTitle_returnsTitle() {
+        val info = MediaFileInfo(
+            uriString = "uri",
+            displayName = "file.mp3",
+            sizeBytes = 100L,
+            title = "My Song Title"
+        )
+        assertEquals("My Song Title", info.cleanTitle)
+    }
+
+    @Test
+    fun cleanTitle_blankTitle_returnsDisplayNameWithoutExtension() {
+        val info = MediaFileInfo(
+            uriString = "uri",
+            displayName = "file.name.with.dots.mp3",
+            sizeBytes = 100L,
+            title = "   "
+        )
+        assertEquals("file.name.with.dots", info.cleanTitle)
+    }
+
+    @Test
+    fun cleanTitle_nullTitle_returnsDisplayNameWithoutExtension() {
+        val info = MediaFileInfo(
+            uriString = "uri",
+            displayName = "song.m4a",
+            sizeBytes = 100L,
+            title = null
+        )
+        assertEquals("song", info.cleanTitle)
+    }
+
+    @Test
+    fun cleanTitle_nullTitleNoExtension_returnsFullDisplayName() {
+        val info = MediaFileInfo(
+            uriString = "uri",
+            displayName = "song_without_extension",
+            sizeBytes = 100L,
+            title = null
+        )
+        assertEquals("song_without_extension", info.cleanTitle)
+    }
+}


### PR DESCRIPTION
🎯 **What:** Added comprehensive unit tests for the `cleanTitle` property in `MediaFileInfo.kt` to ensure fallback logic operates correctly under various scenarios.
📊 **Coverage:** Covered all paths: valid title, blank title, null title, and null title where the `displayName` lacks an extension.
✨ **Result:** Improved overall test coverage and guarantees that the title clean-up logic functions as expected without regressions.

---
*PR created automatically by Jules for task [8671112494603647781](https://jules.google.com/task/8671112494603647781) started by @kimptoc*