### PR TITLE
🔒 Disable insecure backup configuration in automotive module

### DIFF
--- a/automotive/src/main/AndroidManifest.xml
+++ b/automotive/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:appCategory="audio"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"


### PR DESCRIPTION
🎯 **What:** Disabled `android:allowBackup` in the automotive module's AndroidManifest.xml.

⚠️ **Risk:** By default or when explicitly set to `true`, `android:allowBackup` enables the `adb backup` command to extract sensitive application data, including shared preferences and local databases, potentially exposing user data to attackers with physical access or ADB privileges.

🛡️ **Solution:** Changed `android:allowBackup="true"` to `android:allowBackup="false"`. This prevents the extraction of the application's data via ADB backup, thus securing the app's local storage from unauthorized access. Tests were verified to ensure no functionality is broken.

---
*PR created automatically by Jules for task [17322209590023987557](https://jules.google.com/task/17322209590023987557) started by @kimptoc*