### PR TITLE
🧹 [code health] Refactor SettingsScreen state to destructuring to resolve unused import warnings

### DIFF
--- a/mobile/src/main/java/com/example/mymediaplayer/SettingsScreen.kt
+++ b/mobile/src/main/java/com/example/mymediaplayer/SettingsScreen.kt
@@ -24,10 +24,8 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.PasswordVisualTransformation
@@ -57,9 +55,9 @@ fun SettingsScreen(
     onChoosePlaylistSaveFolder: () -> Unit,
     onBack: () -> Unit
 ) {
-    var showCloudAnnouncementSettingsDialog by remember { mutableStateOf(false) }
-    var showManageTrustedBluetoothDialog by remember { mutableStateOf(false) }
-    var showBluetoothDiagnosticsDialog by remember { mutableStateOf(false) }
+    val (showCloudAnnouncementSettingsDialog, setShowCloudAnnouncementSettingsDialog) = remember { mutableStateOf(false) }
+    val (showManageTrustedBluetoothDialog, setShowManageTrustedBluetoothDialog) = remember { mutableStateOf(false) }
+    val (showBluetoothDiagnosticsDialog, setShowBluetoothDiagnosticsDialog) = remember { mutableStateOf(false) }
 
     BackHandler { onBack() }
 
@@ -72,14 +70,14 @@ fun SettingsScreen(
             trackVoiceOutroEnabled = trackVoiceOutroEnabled,
             onToggleTrackVoiceIntro = onToggleTrackVoiceIntro,
             onToggleTrackVoiceOutro = onToggleTrackVoiceOutro,
-            onShowCloudAnnouncementSettingsDialog = { showCloudAnnouncementSettingsDialog = true },
+            onShowCloudAnnouncementSettingsDialog = { setShowCloudAnnouncementSettingsDialog(true) },
             bluetoothAutoPlayEnabled = bluetoothAutoPlayEnabled,
             onToggleBluetoothAutoPlay = onToggleBluetoothAutoPlay,
             onAddCurrentBluetoothDevice = onAddCurrentBluetoothDevice,
-            onShowManageTrustedBluetoothDialog = { showManageTrustedBluetoothDialog = true },
+            onShowManageTrustedBluetoothDialog = { setShowManageTrustedBluetoothDialog(true) },
             onShowBluetoothDiagnosticsDialog = {
                 onRefreshBluetoothDiagnostics()
-                showBluetoothDiagnosticsDialog = true
+                setShowBluetoothDiagnosticsDialog(true)
             },
             onChoosePlaylistSaveFolder = onChoosePlaylistSaveFolder
         )
@@ -92,7 +90,7 @@ fun SettingsScreen(
             debugCloudAnnouncements = debugCloudAnnouncements,
             onSetDebugCloudAnnouncements = onSetDebugCloudAnnouncements,
             onSaveCloudAnnouncementKeys = onSaveCloudAnnouncementKeys,
-            onDismissRequest = { showCloudAnnouncementSettingsDialog = false }
+            onDismissRequest = { setShowCloudAnnouncementSettingsDialog(false) }
         )
     }
 
@@ -101,7 +99,7 @@ fun SettingsScreen(
             trustedBluetoothDevices = trustedBluetoothDevices,
             onRemoveTrustedBluetoothDevice = onRemoveTrustedBluetoothDevice,
             onClearTrustedBluetoothDevices = onClearTrustedBluetoothDevices,
-            onDismissRequest = { showManageTrustedBluetoothDialog = false }
+            onDismissRequest = { setShowManageTrustedBluetoothDialog(false) }
         )
     }
 
@@ -109,7 +107,7 @@ fun SettingsScreen(
         BluetoothDiagnosticsDialog(
             bluetoothDiagnostics = bluetoothDiagnostics,
             onRefreshBluetoothDiagnostics = onRefreshBluetoothDiagnostics,
-            onDismissRequest = { showBluetoothDiagnosticsDialog = false }
+            onDismissRequest = { setShowBluetoothDiagnosticsDialog(false) }
         )
     }
 }
@@ -252,8 +250,8 @@ internal fun CloudAnnouncementSettingsDialog(
     onSaveCloudAnnouncementKeys: (String, String, () -> Unit) -> Unit,
     onDismissRequest: () -> Unit
 ) {
-    var kiloKeyInput by remember { mutableStateOf(cloudAnnouncementKiloKey) }
-    var ttsKeyInput by remember { mutableStateOf(cloudAnnouncementTtsKey) }
+    val (kiloKeyInput, setKiloKeyInput) = remember { mutableStateOf(cloudAnnouncementKiloKey) }
+    val (ttsKeyInput, setTtsKeyInput) = remember { mutableStateOf(cloudAnnouncementTtsKey) }
     AlertDialog(
         onDismissRequest = onDismissRequest,
         title = { Text("AI Announcement Settings") },
@@ -265,7 +263,7 @@ internal fun CloudAnnouncementSettingsDialog(
                 )
                 TextField(
                     value = kiloKeyInput,
-                    onValueChange = { kiloKeyInput = it },
+                    onValueChange = setKiloKeyInput,
                     label = { Text("Kilo API key (optional)") },
                     placeholder = { Text("Leave blank for anonymous") },
                     singleLine = true,
@@ -274,7 +272,7 @@ internal fun CloudAnnouncementSettingsDialog(
                 )
                 TextField(
                     value = ttsKeyInput,
-                    onValueChange = { ttsKeyInput = it },
+                    onValueChange = setTtsKeyInput,
                     label = { Text("Google Cloud TTS key (optional)") },
                     singleLine = true,
                     visualTransformation = PasswordVisualTransformation(),


### PR DESCRIPTION
🎯 **What:**
The code health issue addressed is the removal of supposedly unused imports `androidx.compose.runtime.getValue` and `androidx.compose.runtime.setValue` from `SettingsScreen.kt`. However, simply removing these imports would break compilation because they are used implicitly by Compose's property delegation (`var state by remember { ... }`). To correctly address this without breaking the code, the property delegations have been refactored to use standard state destructuring declarations (`val (state, setState) = remember { ... }`).

💡 **Why:**
This improves maintainability by removing the false-positive unused import warnings while preserving the exact same functionality using a fully supported and idiomatic Jetpack Compose pattern. It also makes the state updates slightly cleaner by directly passing the destructuring setter (e.g. `setKiloKeyInput`) as a callback instead of wrapping it in a lambda.

✅ **Verification:**
The change is safe because destructuring `MutableState` is functionally identical to property delegation (as it implements `component1()` and `component2()`). The full mobile test suite was run (`./gradlew :mobile:testDebugUnitTest`) and passed successfully, confirming no functionality is broken.

✨ **Result:**
The unused import warnings are resolved cleanly, code health is improved, and the code remains completely functional and compiling.

---
*PR created automatically by Jules for task [520765885580509564](https://jules.google.com/task/520765885580509564) started by @kimptoc*