### PR TITLE
🧪 Add tests for replacePlaylists in MediaCacheDatabase

### DIFF
--- a/shared/src/test/java/com/example/mymediaplayer/shared/MediaCacheDatabaseTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/MediaCacheDatabaseTest.kt
@@ -263,4 +263,38 @@ class MediaCacheDatabaseTest {
         val retrievedState = dao.getScanState()
         org.junit.Assert.assertEquals(newState, retrievedState)
     }
+
+    @org.junit.Test
+    fun replacePlaylists() {
+        val oldPlaylist = PlaylistEntity(
+            uriString = "content://old_playlist/1",
+            displayName = "Old Playlist"
+        )
+        dao.insertPlaylists(listOf(oldPlaylist))
+
+        val newPlaylist = PlaylistEntity(
+            uriString = "content://new_playlist/1",
+            displayName = "New Playlist"
+        )
+
+        dao.replacePlaylists(listOf(newPlaylist))
+
+        val playlists = dao.getAllPlaylists()
+        org.junit.Assert.assertEquals(1, playlists.size)
+        org.junit.Assert.assertEquals(newPlaylist, playlists[0])
+    }
+
+    @org.junit.Test
+    fun replacePlaylists_emptyLists() {
+        val oldPlaylist = PlaylistEntity(
+            uriString = "content://old_playlist/1",
+            displayName = "Old Playlist"
+        )
+        dao.insertPlaylists(listOf(oldPlaylist))
+
+        dao.replacePlaylists(emptyList())
+
+        val playlists = dao.getAllPlaylists()
+        org.junit.Assert.assertTrue(playlists.isEmpty())
+    }
 }

--- a/test_plan.md
+++ b/test_plan.md
@@ -1,0 +1,3 @@
+1. Modify `shared/src/test/java/com/example/mymediaplayer/shared/MediaCacheDatabaseTest.kt` to add tests for `replacePlaylists`.
+2. Run the tests to ensure they pass.
+3. Complete pre commit steps to ensure proper testing, verification, review, and reflection are done.


### PR DESCRIPTION
🎯 **What:** Added missing tests for the `replacePlaylists` method in `MediaCacheDatabase.kt`.
📊 **Coverage:** Covered replacing existing playlists with a new list of playlists, as well as replacing with an empty list.
✨ **Result:** Improved test coverage and reliability for the media cache database operations.

---
*PR created automatically by Jules for task [7886521962246675074](https://jules.google.com/task/7886521962246675074) started by @kimptoc*