### PR TITLE
🧹 Refactor redundant `isSelectedPlaylist` checks in MainViewModel

### DIFF
--- a/mobile/src/main/java/com/example/mymediaplayer/MainViewModel.kt
+++ b/mobile/src/main/java/com/example/mymediaplayer/MainViewModel.kt
@@ -949,13 +949,19 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
 
             val isSelectedPlaylist = current.playlist.selectedPlaylist?.uriString == playlist.uriString
 
+            val updatedPlaylist = current.playlist.copy(
+                playlistMessage = "Deleted ${playlist.displayName.removeSuffix(".m3u")}"
+            ).let {
+                if (isSelectedPlaylist) {
+                    it.copy(selectedPlaylist = null, playlistSongs = emptyList())
+                } else {
+                    it
+                }
+            }
+
             _uiState.value = current.copy(
                 scan = current.scan.copy(discoveredPlaylists = updatedPlaylists),
-                playlist = current.playlist.copy(
-                    selectedPlaylist = if (isSelectedPlaylist) null else current.playlist.selectedPlaylist,
-                    playlistSongs = if (isSelectedPlaylist) emptyList() else current.playlist.playlistSongs,
-                    playlistMessage = "Deleted ${playlist.displayName.removeSuffix(".m3u")}"
-                )
+                playlist = updatedPlaylist
             )
             treeUri?.let { tree ->
                 val limit = current.scan.lastScanLimit


### PR DESCRIPTION
🎯 **What:** Extracted the redundant `if (isSelectedPlaylist)` logic inside the data class `copy()` arguments in `deletePlaylist` within `MainViewModel.kt` by grouping the updates using an intermediate variable.

💡 **Why:** This improves readability and maintainability by preventing the same condition from being evaluated multiple times for different property assignments on the same object update.

✅ **Verification:** Verified the code changes locally via standard Android unit tests (`./gradlew :mobile:testDebugUnitTest`). Tests complete successfully and verify there are no side-effects from the data manipulation refactoring.

✨ **Result:** Cleaned up code that effectively eliminates duplicated conditional logic.

---
*PR created automatically by Jules for task [1699955512577940191](https://jules.google.com/task/1699955512577940191) started by @kimptoc*