### PR TITLE
🧹 [code health] use constant log tag in MediaCacheService

### DIFF
--- a/shared/src/main/java/com/example/mymediaplayer/shared/MediaCacheService.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/MediaCacheService.kt
@@ -14,7 +14,10 @@ import kotlinx.coroutines.isActive
 import java.time.Instant
 import java.time.ZoneId
 import java.util.Locale
+import android.util.Log
 import kotlin.coroutines.coroutineContext
+
+private const val TAG = "MediaCacheService"
 
 data class PersistedCache(
     val files: List<MediaFileInfo>,
@@ -455,7 +458,7 @@ class MediaCacheService {
         val durationMs = metadata?.durationMs?.toLongOrNull()
         val resolvedTitle = metadata?.title ?: candidate.name.substringBeforeLast('.')
         if (metadata?.title == null) {
-            android.util.Log.w("MediaCacheService", "No metadata title for ${candidate.name} (uri=${candidate.uri}), using fallback: $resolvedTitle")
+            Log.w(TAG, "No metadata title for ${candidate.name} (uri=${candidate.uri}), using fallback: $resolvedTitle")
         }
         return MediaFileInfo(
             uriString = candidate.uri.toString(),


### PR DESCRIPTION
🎯 **What:** Replaced the hardcoded string literal "MediaCacheService" with a file-level `private const val TAG` in `MediaCacheService.kt` and updated the `Log.w` call to use it.
💡 **Why:** Hardcoded log tags are error-prone and make it harder to maintain or consistently rename tags. Extracting it to a constant improves readability and adherence to standard Android Kotlin conventions.
✅ **Verification:** Ran the `shared` module test suite (`./gradlew :shared:testDebugUnitTest`) to ensure no build issues or regressions were introduced.
✨ **Result:** The log tag is now centrally defined, improving the code health and maintainability of `MediaCacheService.kt`.

---
*PR created automatically by Jules for task [13831661973962054570](https://jules.google.com/task/13831661973962054570) started by @kimptoc*