### PR TITLE
🧪 [testing improvement] Add comprehensive unit tests for PackageValidator

### DIFF
--- a/shared/src/test/java/com/example/mymediaplayer/shared/PackageValidatorTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/PackageValidatorTest.kt
@@ -66,4 +66,42 @@ class PackageValidatorTest {
         pm.setPackagesForUid(uid, "com.malicious.app")
         assertFalse(validator.isCallerValid("com.malicious.app", uid))
     }
+
+    @Test
+    fun isCallerValid_packageNotFound_returnsFalse() {
+        assertFalse(validator.isCallerValid("com.not.found.package", 50000))
+    }
+
+    @Test
+    fun isCallerUidValid_allowsSameUid() {
+        assertTrue(validator.isCallerUidValid(Process.myUid()))
+    }
+
+    @Test
+    fun isCallerUidValid_allowsSystemUid() {
+        assertTrue(validator.isCallerUidValid(Process.SYSTEM_UID))
+        assertTrue(validator.isCallerUidValid(Process.ROOT_UID))
+    }
+
+    @Test
+    fun isCallerUidValid_returnsFalseWhenPackagesIsNull() {
+        val uid = 60000
+        assertFalse(validator.isCallerUidValid(uid))
+    }
+
+    @Test
+    fun isCallerUidValid_returnsTrueWhenValidPackageExistsForUid() {
+        val uid = 70000
+        pm.installPackage(PackageInfo().apply { packageName = "com.google.android.projection.gearhead" })
+        pm.setPackagesForUid(uid, "com.google.android.projection.gearhead")
+        assertTrue(validator.isCallerUidValid(uid))
+    }
+
+    @Test
+    fun isCallerUidValid_returnsFalseWhenOnlyInvalidPackagesExistForUid() {
+        val uid = 80000
+        pm.installPackage(PackageInfo().apply { packageName = "com.malicious.app" })
+        pm.setPackagesForUid(uid, "com.malicious.app")
+        assertFalse(validator.isCallerUidValid(uid))
+    }
 }


### PR DESCRIPTION
🎯 **What:** The `PackageValidator` logic had poor test coverage, specifically missing tests for NameNotFoundException when getting package UID, and complete lack of tests for the `isCallerUidValid` helper function.
📊 **Coverage:** Added tests to ensure `isCallerValid` returns false if `getPackageUid` throws, and added 5 new tests for `isCallerUidValid` covering myUid, SYSTEM_UID/ROOT_UID, null package returns, and valid vs invalid package resolutions.
✨ **Result:** Improved test coverage and reliability for package validation logic.

---
*PR created automatically by Jules for task [13287116405741461921](https://jules.google.com/task/13287116405741461921) started by @kimptoc*