### PR TITLE
🧪 [testing improvement] Cover exception path in fetchKiloText

### DIFF
--- a/shared/src/main/java/com/example/mymediaplayer/shared/AnnouncementPreGenerator.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/AnnouncementPreGenerator.kt
@@ -195,7 +195,8 @@ internal class AnnouncementPreGenerator(
         }
     }
 
-    private suspend fun fetchKiloText(
+    @androidx.annotation.VisibleForTesting
+    internal suspend fun fetchKiloText(
         title: String,
         artist: String?,
         isIntro: Boolean,

--- a/shared/src/test/java/com/example/mymediaplayer/shared/AnnouncementPreGeneratorTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/AnnouncementPreGeneratorTest.kt
@@ -101,4 +101,32 @@ class AnnouncementPreGeneratorTest {
         }
     }
 
+    @Test
+    fun fetchKiloText_exception_returnsNull() = runTest {
+        NetworkQualityCheckerTest.installMockFactory()
+        NetworkQualityCheckerTest.mockFailConnection = true
+
+        try {
+            val context = ApplicationProvider.getApplicationContext<Context>()
+            val preGen = AnnouncementPreGenerator(context, TestScope(this.testScheduler))
+
+            var result: String? = "dummy"
+            val job = launch {
+                result = preGen.fetchKiloText(
+                    title = "Test Title",
+                    artist = "Test Artist",
+                    isIntro = true,
+                    apiKey = "fake_kilo_key"
+                )
+            }
+
+            testScheduler.advanceUntilIdle()
+            job.join()
+
+            assertNull("Text should be null due to simulated network exception", result)
+        } finally {
+            NetworkQualityCheckerTest.mockFailConnection = false
+        }
+    }
+
 }


### PR DESCRIPTION
🎯 **What:** The `fetchKiloText` exception handling block in `AnnouncementPreGenerator` lacked test coverage.
📊 **Coverage:** Added `fetchKiloText_exception_returnsNull` to specifically test the scenario where the Kilo API HTTP request throws an exception, ensuring it gracefully returns `null`. Made `fetchKiloText` internal and added `@VisibleForTesting` to allow direct invocation.
✨ **Result:** Improved test coverage and guaranteed robustness of fallback logic when the network fails.

---
*PR created automatically by Jules for task [808304654664484211](https://jules.google.com/task/808304654664484211) started by @kimptoc*