### PR TITLE
🔒 [security fix] Remove sensitive data from metadata logs

### DIFF
--- a/shared/src/main/java/com/example/mymediaplayer/shared/MediaMetadataHelper.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/MediaMetadataHelper.kt
@@ -22,9 +22,9 @@ object MediaMetadataHelper {
             val genre = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_GENRE)
             val year = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_YEAR)
             val durationMs = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)
-            Log.d(TAG, "extractMetadata uri=$uriString title=$title artist=$artist album=$album genre=$genre")
+            Log.d(TAG, "extractMetadata completed")
             if (title == null && artist == null && album == null) {
-                Log.w(TAG, "No ID3 tags found for: $uriString")
+                Log.w(TAG, "No ID3 tags found for media")
             }
             val info = MediaMetadataInfo(
                 title = title,
@@ -37,7 +37,7 @@ object MediaMetadataHelper {
             metadataCache.put(uriString, info)
             info
         } catch (e: Exception) {
-            Log.e(TAG, "extractMetadata FAILED for $uriString: ${e.javaClass.simpleName}: ${e.message}")
+            Log.e(TAG, "extractMetadata FAILED: ${e.javaClass.simpleName}: ${e.message}")
             null
         } finally {
             try {

--- a/shared/src/main/java/com/example/mymediaplayer/shared/MediaMetadataHelper.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/MediaMetadataHelper.kt
@@ -37,7 +37,7 @@ object MediaMetadataHelper {
             metadataCache.put(uriString, info)
             info
         } catch (e: Exception) {
-            Log.e(TAG, "extractMetadata FAILED: ${e.javaClass.simpleName}: ${e.message}")
+            Log.w(TAG, "Failed to read metadata: ${e.javaClass.simpleName}")
             null
         } finally {
             try {

--- a/shared/src/test/java/com/example/mymediaplayer/shared/MediaMetadataHelperTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/MediaMetadataHelperTest.kt
@@ -94,7 +94,7 @@ class MediaMetadataHelperTest {
 
         val logs = org.robolectric.shadows.ShadowLog.getLogsForTag("MediaMetadataHelper")
         logs.forEach { println("LOG: ${it.type} ${it.msg}") }
-        val warningLog = logs.find { it.type == android.util.Log.WARN && it.msg == "No ID3 tags found for: $uriString" }
+        val warningLog = logs.find { it.type == android.util.Log.WARN && it.msg == "No ID3 tags found for media" }
         org.junit.Assert.assertNotNull("Expected warning log for missing ID3 tags was not found", warningLog)
     }
 }


### PR DESCRIPTION
🎯 **What:**
The vulnerability where user-provided file URIs and media metadata (title, artist, album, genre) were logged in plain text in `MediaMetadataHelper.kt` has been fixed. The test `MediaMetadataHelperTest.kt` asserting the warning log format was also updated.

⚠️ **Risk:**
Logging user metadata directly could lead to unintended privacy leaks if logcat or crash reporting data were accessed by an unauthorized entity.

🛡️ **Solution:**
Replaced the detailed debug, warning, and error logs with generic logs that no longer include the specific file paths or metadata strings, mitigating the data exposure vulnerability.

---
*PR created automatically by Jules for task [11524484899269326321](https://jules.google.com/task/11524484899269326321) started by @kimptoc*