### PR TITLE
🔒 Enforce HTTPS connections to prevent cleartext HTTP traffic

### DIFF
--- a/shared/src/main/java/com/example/mymediaplayer/shared/AnnouncementPreGenerator.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/AnnouncementPreGenerator.kt
@@ -15,7 +15,6 @@ import org.json.JSONArray
 import org.json.JSONObject
 import java.io.File
 import java.io.OutputStreamWriter
-import java.net.HttpURLConnection
 import java.net.URL
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
@@ -274,7 +273,7 @@ internal class AnnouncementPreGenerator(
         withContext(Dispatchers.IO) {
             runCatching {
                 val conn = URL("https://texttospeech.googleapis.com/v1/text:synthesize?key=$apiKey")
-                    .openConnection() as HttpURLConnection
+                    .openConnection() as HttpsURLConnection
                 conn.connectTimeout = 5_000
                 conn.readTimeout = 10_000
                 conn.requestMethod = "POST"

--- a/shared/src/main/java/com/example/mymediaplayer/shared/AnnouncementPreGenerator.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/AnnouncementPreGenerator.kt
@@ -19,6 +19,7 @@ import java.net.HttpURLConnection
 import java.net.URL
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
+import javax.net.ssl.HttpsURLConnection
 
 /**
  * Pre-generates announcement audio for upcoming track intros and outros while the current
@@ -215,7 +216,7 @@ internal class AnnouncementPreGenerator(
 
         try {
             val conn = URL("$KILO_ENDPOINT/chat/completions")
-                .openConnection() as HttpURLConnection
+                .openConnection() as HttpsURLConnection
             conn.connectTimeout = 15_000
             conn.readTimeout = 20_000
             conn.requestMethod = "POST"

--- a/shared/src/main/java/com/example/mymediaplayer/shared/ApiKeyStore.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/ApiKeyStore.kt
@@ -10,7 +10,6 @@ import kotlinx.coroutines.withContext
 import org.json.JSONArray
 import org.json.JSONObject
 import java.io.OutputStreamWriter
-import java.net.HttpURLConnection
 import java.net.URL
 import javax.net.ssl.HttpsURLConnection
 
@@ -90,7 +89,11 @@ object ApiKeyStore {
 
             ValidationResult.Success
         }.getOrElse { e ->
-            ValidationResult.Error("Connection failed: ${e.message}")
+            if (e is ClassCastException) {
+                ValidationResult.Error("Endpoint must use HTTPS")
+            } else {
+                ValidationResult.Error("Connection failed: ${e.message}")
+            }
         }
     }
 

--- a/shared/src/main/java/com/example/mymediaplayer/shared/ApiKeyStore.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/ApiKeyStore.kt
@@ -12,6 +12,7 @@ import org.json.JSONObject
 import java.io.OutputStreamWriter
 import java.net.HttpURLConnection
 import java.net.URL
+import javax.net.ssl.HttpsURLConnection
 
 /**
  * Secure storage for API keys used by [AnnouncementPreGenerator].
@@ -62,7 +63,7 @@ object ApiKeyStore {
     private suspend fun validateKiloKey(apiKey: String): ValidationResult = withContext(Dispatchers.IO) {
         runCatching {
             val conn = URL("${BuildConfig.KILO_ENDPOINT}/chat/completions")
-                .openConnection() as HttpURLConnection
+                .openConnection() as HttpsURLConnection
             conn.connectTimeout = 5_000
             conn.readTimeout = 8_000
             conn.requestMethod = "POST"
@@ -96,7 +97,7 @@ object ApiKeyStore {
     private suspend fun validateTtsKey(apiKey: String): ValidationResult = withContext(Dispatchers.IO) {
         runCatching {
             val conn = URL("https://texttospeech.googleapis.com/v1/text:synthesize?key=$apiKey")
-                .openConnection() as HttpURLConnection
+                .openConnection() as HttpsURLConnection
             conn.connectTimeout = 5_000
             conn.readTimeout = 8_000
             conn.requestMethod = "POST"


### PR DESCRIPTION
🎯 **What:** The codebase previously used `HttpURLConnection` to communicate with external APIs (Kilo API and Google Cloud TTS). While the Kilo endpoint defaults to HTTPS, it could be overridden via build configuration to an HTTP endpoint. The connections have been updated to explicitly cast to `HttpsURLConnection`.

⚠️ **Risk:** If the `BuildConfig.KILO_ENDPOINT` was configured with an `http://` scheme, the app would inadvertently transmit sensitive data (such as API keys in the Authorization header and potentially user data) over unencrypted cleartext HTTP traffic. This leaves the data vulnerable to interception (Man-in-the-Middle attacks).

🛡️ **Solution:** By casting the result of `URL(...).openConnection()` to `javax.net.ssl.HttpsURLConnection` instead of `HttpURLConnection`, we enforce that the connection must be HTTPS. In Java/Kotlin, `openConnection()` creates the connection object but does not immediately establish the network connection. If an `http://` URL is provided, `openConnection()` returns an `HttpURLConnection` implementation, and the cast to `HttpsURLConnection` immediately fails with a `ClassCastException`. This halts execution *before* any cleartext traffic is sent over the network. The existing error handling safely catches this exception.

---
*PR created automatically by Jules for task [5317736276225947099](https://jules.google.com/task/5317736276225947099) started by @kimptoc*