### PR TITLE
🧪 [testing improvement] Cover getOrElse block in NetworkQualityChecker

### DIFF
--- a/shared/src/test/java/com/example/mymediaplayer/shared/NetworkQualityCheckerTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/NetworkQualityCheckerTest.kt
@@ -135,6 +135,17 @@ class NetworkQualityCheckerTest {
     }
 
     @Test
+    fun check_runCatchingException_returnsPoor() = runBlocking {
+        setupNetworkForPing()
+        NetworkQualityChecker.testInterceptor = okhttp3.Interceptor { chain ->
+            throw RuntimeException("Simulated unexpected error")
+        }
+
+        assertEquals(NetworkQualityChecker.Quality.POOR, checker.check())
+    }
+
+
+    @Test
     fun check_returnsCachedResult() = runBlocking {
         shadowConnectivityManager.setDefaultNetworkActive(false)
 


### PR DESCRIPTION
🎯 **What:** The `getOrElse` exception handling block within `runCatching` in `NetworkQualityChecker` was previously uncovered by unit tests. This patch introduces testing to simulate an unexpected exception during the OkHttp HEAD request network check to verify proper error handling.

📊 **Coverage:**
* Added test `check_runCatchingException_returnsPoor` which hooks into the test OkHttp Interceptor and throws a `RuntimeException`. This successfully triggers the targeted `getOrElse` block execution path.

✨ **Result:** Increased test coverage by validating that unexpected runtime exceptions during the network check properly fallback to reporting `Quality.POOR` without crashing the application.

---
*PR created automatically by Jules for task [3137614686591486462](https://jules.google.com/task/3137614686591486462) started by @kimptoc*