### PR TITLE
🧹 [code health improvement] Refactor manual file extension extraction into reusable extension

### DIFF
--- a/shared/src/main/java/com/example/mymediaplayer/shared/MediaCacheService.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/MediaCacheService.kt
@@ -179,7 +179,7 @@ class MediaCacheService {
                 )
                 outIds.add(id)
                 songsFound = out.size
-                val ext = fileExtension(displayName)
+                val ext = displayName.fileExtension()
                 extensionCounts[ext] = (extensionCounts[ext] ?: 0) + 1
                 if (songsFound % 200 == 0 || songsFound == 1) {
                     onProgress?.invoke(songsFound, 0)
@@ -430,7 +430,7 @@ class MediaCacheService {
             for (result in accepted) {
                 processed += 1
                 songsFound = processed
-                val ext = fileExtension(result.displayName)
+                val ext = result.displayName.fileExtension()
                 extensionCounts[ext] = (extensionCounts[ext] ?: 0) + 1
                 scanContext.onProgress?.invoke(songsFound, foldersScanned)
             }
@@ -754,7 +754,7 @@ class MediaCacheService {
         }
         if (mime == "application/ogg" || mime == "application/x-ogg") return true
 
-        return SUPPORTED_AUDIO_EXTENSIONS.contains(fileExtension(nameLowercase))
+        return SUPPORTED_AUDIO_EXTENSIONS.contains(nameLowercase.fileExtension())
     }
 
     internal fun isSupportedPlaylistFile(nameLowercase: String, mimeType: String?): Boolean {
@@ -777,12 +777,6 @@ class MediaCacheService {
             !metadata.artist.isNullOrBlank() ||
             !metadata.album.isNullOrBlank() ||
             !metadata.genre.isNullOrBlank()
-    }
-
-    private fun fileExtension(displayName: String): String {
-        val dot = displayName.lastIndexOf('.')
-        if (dot < 0 || dot == displayName.lastIndex) return "(none)"
-        return displayName.substring(dot).lowercase(Locale.US)
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)

--- a/shared/src/main/java/com/example/mymediaplayer/shared/StringExt.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/StringExt.kt
@@ -1,0 +1,12 @@
+package com.example.mymediaplayer.shared
+
+import java.util.Locale
+
+/**
+ * Returns the file extension of the string representation of a filename,
+ * including the dot (e.g., ".mp3"), or "(none)" if no extension is found.
+ */
+fun String.fileExtension(): String {
+    val ext = this.substringAfterLast('.', "")
+    return if (ext.isNotEmpty()) ".$ext".lowercase(Locale.US) else "(none)"
+}

--- a/shared/src/test/java/com/example/mymediaplayer/shared/StringExtTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/StringExtTest.kt
@@ -1,0 +1,16 @@
+package com.example.mymediaplayer.shared
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class StringExtTest {
+    @Test
+    fun fileExtension_extractsCorrectly() {
+        assertEquals(".mp3", "file.mp3".fileExtension())
+        assertEquals("(none)", "no_ext".fileExtension())
+        assertEquals("(none)", "file.".fileExtension())
+        assertEquals(".hidden", ".hidden".fileExtension())
+        assertEquals(".jpg", "file.NAME.JPG".fileExtension())
+        assertEquals(".mp4", "some/path.to/file.mp4".fileExtension())
+    }
+}


### PR DESCRIPTION
🎯 **What:** Extracted the manual `fileExtension` method in `MediaCacheService` into a reusable `String.fileExtension()` extension method in a new utility file (`StringExt.kt`), replacing `.lastIndexOf('.')` calculations with an idiomatic `substringAfterLast`.

💡 **Why:** The previous implementation was a private function specific to `MediaCacheService` that unnecessarily calculated string indices manually. Promoting this logic to a string extension improves testability, readability, and allows it to be consistently utilized across the entire project without code duplication.

✅ **Verification:** Added `StringExtTest` with exhaustive edge-case coverage and successfully verified that existing `MediaCacheService` behaviors function correctly via the `./gradlew :shared:testDebugUnitTest` module test suite.

✨ **Result:** A cleaner, more idiomatic, safely tested, and widely accessible mechanism for parsing file extensions.

---
*PR created automatically by Jules for task [16260556296061832275](https://jules.google.com/task/16260556296061832275) started by @kimptoc*