### PR TITLE
🧹 Remove leftover Jules planning artifact

### DIFF
--- a/test_plan.md
+++ b/test_plan.md
@@ -1,3 +1,0 @@
-1. Modify `shared/src/test/java/com/example/mymediaplayer/shared/MediaCacheDatabaseTest.kt` to add tests for `replacePlaylists`.
-2. Run the tests to ensure they pass.
-3. Complete pre commit steps to ensure proper testing, verification, review, and reflection are done.


### PR DESCRIPTION
## Summary
- Delete `test_plan.md` from repo root — Jules planning scratchpad that landed via #274 (Kilo missed flagging it at the time, unlike the matching `test_plan.txt` in #277 and `test_robo.sh` in #287)

## Test plan
- [x] CI build green