### PR TITLE
🔒 Fix: Secure Google TTS API key transmission

### DIFF
--- a/shared/src/main/java/com/example/mymediaplayer/shared/AnnouncementPreGenerator.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/AnnouncementPreGenerator.kt
@@ -306,7 +306,8 @@ internal class AnnouncementPreGenerator(
                 val requestBody = bodyString.toRequestBody("application/json; charset=utf-8".toMediaType())
 
                 val request = Request.Builder()
-                    .url("https://texttospeech.googleapis.com/v1/text:synthesize?key=$apiKey")
+                    .url("https://texttospeech.googleapis.com/v1/text:synthesize")
+                    .header("x-goog-api-key", apiKey)
                     .post(requestBody)
                     .build()
 


### PR DESCRIPTION
🎯 **What:** The Google TTS API key was being sent in the URL query parameter instead of a header.
⚠️ **Risk:** Sending sensitive credentials like API keys in URL query parameters can expose them in server logs, proxy logs, and browser history, leading to unauthorized access and potential financial cost or quota exhaustion.
🛡️ **Solution:** Updated the request to send the API key securely via the `x-goog-api-key` HTTP header, preventing exposure in URLs.

---
*PR created automatically by Jules for task [9540556776348922491](https://jules.google.com/task/9540556776348922491) started by @kimptoc*