### PR TITLE
🔒 Fix Sensitive API Key in URL Query Parameter

### DIFF
--- a/shared/src/main/java/com/example/mymediaplayer/shared/AnnouncementPreGenerator.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/AnnouncementPreGenerator.kt
@@ -306,7 +306,8 @@ internal class AnnouncementPreGenerator(
                 val requestBody = bodyString.toRequestBody("application/json; charset=utf-8".toMediaType())
 
                 val request = Request.Builder()
-                    .url("https://texttospeech.googleapis.com/v1/text:synthesize?key=$apiKey")
+                    .url("https://texttospeech.googleapis.com/v1/text:synthesize")
+                    .header("x-goog-api-key", apiKey)
                     .post(requestBody)
                     .build()
 


### PR DESCRIPTION
🎯 **What:** The `apiKey` was being included in the URL query string when calling the Google TTS API.
⚠️ **Risk:** Query parameters can be logged by intermediary servers, proxies, or stored in browser histories, exposing the sensitive API key to potential attackers.
🛡️ **Solution:** The `apiKey` is now sent securely in the `x-goog-api-key` HTTP header instead of the URL query string.

---
*PR created automatically by Jules for task [13113519934705723257](https://jules.google.com/task/13113519934705723257) started by @kimptoc*