### PR TITLE
🔒 Fix: Securely transmit API key in header

### DIFF
--- a/shared/src/main/java/com/example/mymediaplayer/shared/AnnouncementPreGenerator.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/AnnouncementPreGenerator.kt
@@ -306,7 +306,8 @@ internal class AnnouncementPreGenerator(
                 val requestBody = bodyString.toRequestBody("application/json; charset=utf-8".toMediaType())
 
                 val request = Request.Builder()
-                    .url("https://texttospeech.googleapis.com/v1/text:synthesize?key=$apiKey")
+                    .url("https://texttospeech.googleapis.com/v1/text:synthesize")
+                    .header("x-goog-api-key", apiKey)
                     .post(requestBody)
                     .build()
 

--- a/shared/src/test/java/com/example/mymediaplayer/shared/AnnouncementPreGeneratorTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/AnnouncementPreGeneratorTest.kt
@@ -126,7 +126,7 @@ class AnnouncementPreGeneratorTest {
 
     @Test
     fun fetchKiloText_exception_returnsNull() = runTest {
-        NetworkQualityCheckerTest.installMockFactory()
+
         NetworkQualityCheckerTest.mockFailConnection = true
 
         try {

--- a/shared/src/test/java/com/example/mymediaplayer/shared/NetworkQualityBenchmarkTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/NetworkQualityBenchmarkTest.kt
@@ -45,7 +45,7 @@ class NetworkQualityBenchmarkTest {
         shadowOf(connectivityManager).setNetworkCapabilities(network, capabilities)
         checker.invalidate()
 
-        NetworkQualityCheckerTest.installMockFactory()
+
         NetworkQualityCheckerTest.mockLatencyMs = 5L // Use small latency to speed up local tests
         NetworkQualityCheckerTest.mockFailConnection = false
 

--- a/shared/src/test/java/com/example/mymediaplayer/shared/NetworkQualityCheckerTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/NetworkQualityCheckerTest.kt
@@ -34,35 +34,6 @@ class NetworkQualityCheckerTest {
     companion object {
         var mockLatencyMs: Long = 0
         var mockFailConnection = false
-        var factoryInstalled = false
-
-        fun installMockFactory() {
-            if (!factoryInstalled) {
-                try {
-                    URL.setURLStreamHandlerFactory { protocol ->
-                        if (protocol == "https") {
-                            object : URLStreamHandler() {
-                                override fun openConnection(u: URL): URLConnection {
-                                    return object : HttpURLConnection(u) {
-                                        override fun connect() {
-                                            if (mockFailConnection) throw java.io.IOException("Mock connection failed")
-                                            Thread.sleep(mockLatencyMs) // simulate latency
-                                        }
-                                        override fun disconnect() {}
-                                        override fun usingProxy(): Boolean = false
-                                    }
-                                }
-                            }
-                        } else {
-                            null
-                        }
-                    }
-                    factoryInstalled = true
-                } catch (e: Error) {
-                    // Factory already set
-                }
-            }
-        }
     }
 
     @Before
@@ -75,8 +46,6 @@ class NetworkQualityCheckerTest {
 
         mockLatencyMs = 0
         mockFailConnection = false
-
-        installMockFactory()
 
         NetworkQualityChecker.testInterceptor = okhttp3.Interceptor { chain ->
             val request = chain.request()


### PR DESCRIPTION
🎯 **What:** The Google TTS API key is currently being transmitted as a URL query parameter (`?key=$apiKey`), which is insecure.
⚠️ **Risk:** URL query parameters are often logged by servers, proxies, and network intermediaries. An attacker could extract the API key from these logs and use it to make unauthorized requests, potentially leading to quota exhaustion or billing charges.
🛡️ **Solution:** Moved the API key from the URL query parameter to the `x-goog-api-key` HTTP header, which is standard practice for Google Cloud APIs and ensures the key is not exposed in URL logs. Also, fixed a test infrastructure issue where a global `URLStreamHandlerFactory` in `NetworkQualityCheckerTest` was breaking Robolectric's internal Maven artifact fetching.

---
*PR created automatically by Jules for task [9574130247181100025](https://jules.google.com/task/9574130247181100025) started by @kimptoc*