### PR TITLE
🔒 Securely pass TTS API key via HTTP header

### DIFF
--- a/shared/src/main/java/com/example/mymediaplayer/shared/AnnouncementPreGenerator.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/AnnouncementPreGenerator.kt
@@ -306,7 +306,8 @@ internal class AnnouncementPreGenerator(
                 val requestBody = bodyString.toRequestBody("application/json; charset=utf-8".toMediaType())
 
                 val request = Request.Builder()
-                    .url("https://texttospeech.googleapis.com/v1/text:synthesize?key=$apiKey")
+                    .url("https://texttospeech.googleapis.com/v1/text:synthesize")
+                    .header("X-Goog-Api-Key", apiKey)
                     .post(requestBody)
                     .build()
 

--- a/shared/src/main/java/com/example/mymediaplayer/shared/ApiKeyStore.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/ApiKeyStore.kt
@@ -97,12 +97,13 @@ object ApiKeyStore {
 
     private suspend fun validateTtsKey(apiKey: String): ValidationResult = withContext(Dispatchers.IO) {
         runCatching {
-            val conn = URL("https://texttospeech.googleapis.com/v1/text:synthesize?key=$apiKey")
+            val conn = URL("https://texttospeech.googleapis.com/v1/text:synthesize")
                 .openConnection() as HttpsURLConnection
             conn.connectTimeout = 5_000
             conn.readTimeout = 8_000
             conn.requestMethod = "POST"
             conn.setRequestProperty("content-type", "application/json")
+            conn.setRequestProperty("X-Goog-Api-Key", apiKey)
             conn.doOutput = true
 
             val body = JSONObject().apply {


### PR DESCRIPTION
🎯 **What:** Moving the Google TTS API key out of the URL query parameters and into the `X-Goog-Api-Key` HTTP header in both `ApiKeyStore.kt` and `AnnouncementPreGenerator.kt`.
⚠️ **Risk:** Query parameters can be leaked in HTTP referrers, proxies, logs, or interceptors, exposing the sensitive API key.
🛡️ **Solution:** Supplying the API key as a request header prevents URL-based secret leakage, adhering to Google Cloud's authentication best practices for REST endpoints.

---
*PR created automatically by Jules for task [6283524427027125295](https://jules.google.com/task/6283524427027125295) started by @kimptoc*