### PR TITLE
🧪 Add tests for MainActivity voice search intent handling

### DIFF
--- a/mobile/src/test/java/com/example/mymediaplayer/MainActivityTest.kt
+++ b/mobile/src/test/java/com/example/mymediaplayer/MainActivityTest.kt
@@ -1,0 +1,103 @@
+package com.example.mymediaplayer
+
+import android.app.SearchManager
+import android.content.Intent
+import android.os.Bundle
+import android.provider.MediaStore
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Robolectric
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = intArrayOf(33))
+class MainActivityTest {
+
+    @Test
+    fun testVoiceSearchIntent_extractsExpectedExtras() {
+        val intent = Intent("android.media.action.MEDIA_PLAY_FROM_SEARCH")
+        intent.putExtra(SearchManager.QUERY, "test query")
+        intent.putExtra(MediaStore.EXTRA_MEDIA_TITLE, "test title")
+        intent.putExtra(MediaStore.EXTRA_MEDIA_ARTIST, "test artist")
+
+        val controller = Robolectric.buildActivity(MainActivity::class.java, intent)
+        val activity = controller.create().get()
+
+        val pendingVoiceSearchQueryField = MainActivity::class.java.getDeclaredField("pendingVoiceSearchQuery")
+        pendingVoiceSearchQueryField.isAccessible = true
+        val query = pendingVoiceSearchQueryField.get(activity) as? String
+
+        assertEquals("test query", query)
+
+        val pendingVoiceSearchExtrasField = MainActivity::class.java.getDeclaredField("pendingVoiceSearchExtras")
+        pendingVoiceSearchExtrasField.isAccessible = true
+        val extras = pendingVoiceSearchExtrasField.get(activity) as? Bundle
+
+        assertNotNull(extras)
+        assertEquals("test title", extras?.getString(MediaStore.EXTRA_MEDIA_TITLE))
+        assertEquals("test artist", extras?.getString(MediaStore.EXTRA_MEDIA_ARTIST))
+    }
+
+    @Test
+    fun testVoiceSearchIntent_ignoresDisallowedExtras() {
+        val intent = Intent("android.media.action.MEDIA_PLAY_FROM_SEARCH")
+        intent.putExtra(SearchManager.QUERY, "test query")
+        intent.putExtra("disallowed_extra_key", "disallowed value")
+        intent.putExtra(MediaStore.EXTRA_MEDIA_ALBUM, "test album")
+
+        val controller = Robolectric.buildActivity(MainActivity::class.java, intent)
+        val activity = controller.create().get()
+
+        val pendingVoiceSearchExtrasField = MainActivity::class.java.getDeclaredField("pendingVoiceSearchExtras")
+        pendingVoiceSearchExtrasField.isAccessible = true
+        val extras = pendingVoiceSearchExtrasField.get(activity) as? Bundle
+
+        assertNotNull(extras)
+        assertEquals("test album", extras?.getString(MediaStore.EXTRA_MEDIA_ALBUM))
+        assertEquals(null, extras?.getString("disallowed_extra_key"))
+    }
+
+    @Test
+    fun testVoiceSearchIntent_handlesMissingQuery() {
+        val intent = Intent("android.media.action.MEDIA_PLAY_FROM_SEARCH")
+
+        val controller = Robolectric.buildActivity(MainActivity::class.java, intent)
+        val activity = controller.create().get()
+
+        val pendingVoiceSearchQueryField = MainActivity::class.java.getDeclaredField("pendingVoiceSearchQuery")
+        pendingVoiceSearchQueryField.isAccessible = true
+        val query = pendingVoiceSearchQueryField.get(activity) as? String
+
+        assertEquals("", query)
+    }
+
+    @Test
+    fun testVoiceSearchIntent_truncatesLongQueryAndExtras() {
+        val intent = Intent("android.media.action.MEDIA_PLAY_FROM_SEARCH")
+        val longString = "a".repeat(600)
+        intent.putExtra(SearchManager.QUERY, longString)
+        intent.putExtra(MediaStore.EXTRA_MEDIA_GENRE, longString)
+
+        val controller = Robolectric.buildActivity(MainActivity::class.java, intent)
+        val activity = controller.create().get()
+
+        val pendingVoiceSearchQueryField = MainActivity::class.java.getDeclaredField("pendingVoiceSearchQuery")
+        pendingVoiceSearchQueryField.isAccessible = true
+        val query = pendingVoiceSearchQueryField.get(activity) as? String
+
+        assertEquals(500, query?.length)
+        assertEquals("a".repeat(500), query)
+
+        val pendingVoiceSearchExtrasField = MainActivity::class.java.getDeclaredField("pendingVoiceSearchExtras")
+        pendingVoiceSearchExtrasField.isAccessible = true
+        val extras = pendingVoiceSearchExtrasField.get(activity) as? Bundle
+
+        assertNotNull(extras)
+        val genre = extras?.getString(MediaStore.EXTRA_MEDIA_GENRE)
+        assertEquals(500, genre?.length)
+        assertEquals("a".repeat(500), genre)
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was missing test coverage for `MainActivity.kt` specifically regarding its parsing of voice search intents (`ACTION_MEDIA_PLAY_FROM_SEARCH`).
📊 **Coverage:** Scenarios tested include successful extraction of expected query and extras, ignoring disallowed extras, handling a missing query gracefully, and ensuring long queries and extras are safely truncated to 500 characters.
✨ **Result:** Test coverage for `MainActivity` intent handling logic has been added via Robolectric, ensuring it correctly and safely parses incoming search commands.

---
*PR created automatically by Jules for task [12161913634078118773](https://jules.google.com/task/12161913634078118773) started by @kimptoc*