### PR TITLE
🧪 Added tests for EncryptedPrefsManager

### DIFF
--- a/shared/src/test/java/com/example/mymediaplayer/shared/EncryptedPrefsManagerTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/EncryptedPrefsManagerTest.kt
@@ -51,16 +51,20 @@ class EncryptedPrefsManagerTest {
 
         @Implementation
         fun build(): androidx.security.crypto.MasterKey {
-            // Because MasterKey is internal and we don't have mockito available,
-            // Unsafe is used to create a stub instance of MasterKey to bypass AndroidKeyStore exceptions during tests.
             val cls = androidx.security.crypto.MasterKey::class.java
-            val unsafeClass = Class.forName("sun.misc.Unsafe")
-            val theUnsafe = unsafeClass.getDeclaredField("theUnsafe")
-            theUnsafe.isAccessible = true
-            val unsafe = theUnsafe.get(null)
-            val allocateInstance = unsafeClass.getMethod("allocateInstance", Class::class.java)
+            val constructor = cls.declaredConstructors.first()
+            constructor.isAccessible = true
 
-            return allocateInstance.invoke(unsafe, cls) as androidx.security.crypto.MasterKey
+            val params = constructor.parameterTypes
+            val constructorArgs = params.map { type ->
+                when (type) {
+                    String::class.java -> "test_alias"
+                    Context::class.java -> ApplicationProvider.getApplicationContext<Context>()
+                    else -> null // KeyGenParameterSpec
+                }
+            }.toTypedArray()
+
+            return constructor.newInstance(*constructorArgs) as androidx.security.crypto.MasterKey
         }
     }
 

--- a/shared/src/test/java/com/example/mymediaplayer/shared/EncryptedPrefsManagerTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/EncryptedPrefsManagerTest.kt
@@ -3,6 +3,8 @@ package com.example.mymediaplayer.shared
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotSame
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertSame
 import org.junit.Before
@@ -52,7 +54,7 @@ class EncryptedPrefsManagerTest {
         @Implementation
         fun build(): androidx.security.crypto.MasterKey {
             val cls = androidx.security.crypto.MasterKey::class.java
-            val constructor = cls.declaredConstructors.firstOrNull { it.parameterTypes.size == 3 }
+            val constructor = cls.declaredConstructors.firstOrNull { it.parameterTypes.size == 2 }
                  ?: cls.declaredConstructors.first()
             constructor.isAccessible = true
 
@@ -71,8 +73,6 @@ class EncryptedPrefsManagerTest {
 
     @Before
     fun setup() {
-        // Use reflection to clear the cache instead to ensure test isolation
-        // without relying on clearCacheForTesting.
         val field = EncryptedPrefsManager::class.java.getDeclaredField("prefsInstances")
         field.isAccessible = true
         val map = field.get(EncryptedPrefsManager) as java.util.concurrent.ConcurrentHashMap<*, *>
@@ -87,5 +87,41 @@ class EncryptedPrefsManagerTest {
 
         val prefs2 = EncryptedPrefsManager.createOrGet(context, "test_prefs")
         assertSame(prefs, prefs2)
+    }
+
+    @Test
+    fun testDifferentFilesYieldDifferentInstances() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val prefs1 = EncryptedPrefsManager.createOrGet(context, "test_prefs_1")
+        val prefs2 = EncryptedPrefsManager.createOrGet(context, "test_prefs_2")
+
+        assertNotSame(prefs1, prefs2)
+    }
+
+    @Test
+    fun testClearCache() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val prefs1 = EncryptedPrefsManager.createOrGet(context, "test_prefs")
+
+        EncryptedPrefsManager.clearCacheForTesting()
+
+        val prefs2 = EncryptedPrefsManager.createOrGet(context, "test_prefs")
+
+        // Since we are mocking EncryptedSharedPreferences to return standard SharedPreferences,
+        // calling createOrGet twice with the SAME file name ("test_prefs") and context WILL return the same
+        // SharedPreferences instance internally from Android, even if our cache is cleared.
+        // The cache simply avoids initializing Keystore if we already have it.
+        // Therefore, we can't test assertNotSame here with standard Robolectric getSharedPreferences.
+        // Instead, we just verify it doesn't crash and returns a non-null instance again.
+        assertNotNull(prefs2)
+    }
+
+    @Test
+    fun testPutAndGet() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val prefs = EncryptedPrefsManager.createOrGet(context, "test_prefs")
+
+        prefs.edit().putString("key", "value").commit()
+        assertEquals("value", prefs.getString("key", null))
     }
 }

--- a/shared/src/test/java/com/example/mymediaplayer/shared/EncryptedPrefsManagerTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/EncryptedPrefsManagerTest.kt
@@ -2,11 +2,14 @@ package com.example.mymediaplayer.shared
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
 import androidx.test.core.app.ApplicationProvider
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotSame
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -15,6 +18,7 @@ import org.robolectric.annotation.Config
 import org.robolectric.annotation.Implementation
 import org.robolectric.annotation.Implements
 import android.os.Build
+import java.util.concurrent.ConcurrentHashMap
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [Build.VERSION_CODES.O], shadows = [EncryptedPrefsManagerTest.ShadowEncryptedSharedPreferences::class, EncryptedPrefsManagerTest.ShadowMasterKeyBuilder::class])
@@ -32,19 +36,16 @@ class EncryptedPrefsManagerTest {
                 prefKeyEncryptionScheme: androidx.security.crypto.EncryptedSharedPreferences.PrefKeyEncryptionScheme,
                 prefValueEncryptionScheme: androidx.security.crypto.EncryptedSharedPreferences.PrefValueEncryptionScheme
             ): SharedPreferences {
-                return context.getSharedPreferences(fileName, Context.MODE_PRIVATE)
+                return context.getSharedPreferences(fileName + java.util.UUID.randomUUID().toString(), Context.MODE_PRIVATE)
             }
         }
     }
 
     @Implements(androidx.security.crypto.MasterKey.Builder::class)
     class ShadowMasterKeyBuilder {
-        @org.robolectric.annotation.RealObject
-        private lateinit var realObject: androidx.security.crypto.MasterKey.Builder
 
-        @Implementation
-        fun __constructor__(context: Context) {
-        }
+        @org.robolectric.annotation.RealObject
+        lateinit var realObject: androidx.security.crypto.MasterKey.Builder
 
         @Implementation
         fun setKeyScheme(keyScheme: androidx.security.crypto.MasterKey.KeyScheme): androidx.security.crypto.MasterKey.Builder {
@@ -55,7 +56,7 @@ class EncryptedPrefsManagerTest {
         fun build(): androidx.security.crypto.MasterKey {
             val cls = androidx.security.crypto.MasterKey::class.java
             val constructor = cls.declaredConstructors.firstOrNull { it.parameterTypes.size == 2 }
-                 ?: cls.declaredConstructors.first()
+                 ?: error("Expected 2-param MasterKey constructor, found: ${cls.declaredConstructors.map { it.parameterTypes.size }}")
             constructor.isAccessible = true
 
             val params = constructor.parameterTypes
@@ -63,7 +64,7 @@ class EncryptedPrefsManagerTest {
                 when (type) {
                     String::class.java -> "test_alias"
                     Context::class.java -> ApplicationProvider.getApplicationContext<Context>()
-                    else -> null // KeyGenParameterSpec
+                    else -> KeyGenParameterSpec.Builder("test_alias", KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT).build()
                 }
             }.toTypedArray()
 
@@ -75,7 +76,7 @@ class EncryptedPrefsManagerTest {
     fun setup() {
         val field = EncryptedPrefsManager::class.java.getDeclaredField("prefsInstances")
         field.isAccessible = true
-        val map = field.get(EncryptedPrefsManager) as java.util.concurrent.ConcurrentHashMap<*, *>
+        val map = field.get(EncryptedPrefsManager) as ConcurrentHashMap<*, *>
         map.clear()
     }
 
@@ -101,19 +102,16 @@ class EncryptedPrefsManagerTest {
     @Test
     fun testClearCache() {
         val context = ApplicationProvider.getApplicationContext<Context>()
-        val prefs1 = EncryptedPrefsManager.createOrGet(context, "test_prefs")
+        EncryptedPrefsManager.createOrGet(context, "test_prefs")
 
         EncryptedPrefsManager.clearCacheForTesting()
 
-        val prefs2 = EncryptedPrefsManager.createOrGet(context, "test_prefs")
+        // Verify the internal prefsInstances map is actually cleared
+        val field = EncryptedPrefsManager::class.java.getDeclaredField("prefsInstances")
+        field.isAccessible = true
+        val map = field.get(EncryptedPrefsManager) as ConcurrentHashMap<*, *>
 
-        // Since we are mocking EncryptedSharedPreferences to return standard SharedPreferences,
-        // calling createOrGet twice with the SAME file name ("test_prefs") and context WILL return the same
-        // SharedPreferences instance internally from Android, even if our cache is cleared.
-        // The cache simply avoids initializing Keystore if we already have it.
-        // Therefore, we can't test assertNotSame here with standard Robolectric getSharedPreferences.
-        // Instead, we just verify it doesn't crash and returns a non-null instance again.
-        assertNotNull(prefs2)
+        assertTrue(map.isEmpty())
     }
 
     @Test

--- a/shared/src/test/java/com/example/mymediaplayer/shared/EncryptedPrefsManagerTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/EncryptedPrefsManagerTest.kt
@@ -1,0 +1,81 @@
+package com.example.mymediaplayer.shared
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertSame
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.Implementation
+import org.robolectric.annotation.Implements
+import android.os.Build
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.O], shadows = [EncryptedPrefsManagerTest.ShadowEncryptedSharedPreferences::class, EncryptedPrefsManagerTest.ShadowMasterKeyBuilder::class])
+class EncryptedPrefsManagerTest {
+
+    @Implements(androidx.security.crypto.EncryptedSharedPreferences::class)
+    class ShadowEncryptedSharedPreferences {
+        companion object {
+            @Implementation
+            @JvmStatic
+            fun create(
+                context: Context,
+                fileName: String,
+                masterKey: androidx.security.crypto.MasterKey,
+                prefKeyEncryptionScheme: androidx.security.crypto.EncryptedSharedPreferences.PrefKeyEncryptionScheme,
+                prefValueEncryptionScheme: androidx.security.crypto.EncryptedSharedPreferences.PrefValueEncryptionScheme
+            ): SharedPreferences {
+                return context.getSharedPreferences(fileName, Context.MODE_PRIVATE)
+            }
+        }
+    }
+
+    @Implements(androidx.security.crypto.MasterKey.Builder::class)
+    class ShadowMasterKeyBuilder {
+        @org.robolectric.annotation.RealObject
+        lateinit var realObject: androidx.security.crypto.MasterKey.Builder
+
+        @Implementation
+        fun __constructor__(context: Context) {
+        }
+
+        @Implementation
+        fun setKeyScheme(keyScheme: androidx.security.crypto.MasterKey.KeyScheme): androidx.security.crypto.MasterKey.Builder {
+             return realObject
+        }
+
+        @Implementation
+        fun build(): androidx.security.crypto.MasterKey {
+            // Because MasterKey is internal and we don't have mockito available,
+            // Unsafe is used to create a stub instance of MasterKey to bypass AndroidKeyStore exceptions during tests.
+            val cls = androidx.security.crypto.MasterKey::class.java
+            val unsafeClass = Class.forName("sun.misc.Unsafe")
+            val theUnsafe = unsafeClass.getDeclaredField("theUnsafe")
+            theUnsafe.isAccessible = true
+            val unsafe = theUnsafe.get(null)
+            val allocateInstance = unsafeClass.getMethod("allocateInstance", Class::class.java)
+
+            return allocateInstance.invoke(unsafe, cls) as androidx.security.crypto.MasterKey
+        }
+    }
+
+    @Before
+    fun setup() {
+        EncryptedPrefsManager.clearCacheForTesting()
+    }
+
+    @Test
+    fun testCreateOrGet() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val prefs = EncryptedPrefsManager.createOrGet(context, "test_prefs")
+        assertNotNull(prefs)
+
+        val prefs2 = EncryptedPrefsManager.createOrGet(context, "test_prefs")
+        assertSame(prefs, prefs2)
+    }
+}

--- a/shared/src/test/java/com/example/mymediaplayer/shared/EncryptedPrefsManagerTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/EncryptedPrefsManagerTest.kt
@@ -17,11 +17,10 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.Implementation
 import org.robolectric.annotation.Implements
-import android.os.Build
 import java.util.concurrent.ConcurrentHashMap
 
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [Build.VERSION_CODES.O], shadows = [EncryptedPrefsManagerTest.ShadowEncryptedSharedPreferences::class, EncryptedPrefsManagerTest.ShadowMasterKeyBuilder::class])
+@Config(sdk = [34], shadows = [EncryptedPrefsManagerTest.ShadowEncryptedSharedPreferences::class, EncryptedPrefsManagerTest.ShadowMasterKeyBuilder::class])
 class EncryptedPrefsManagerTest {
 
     @Implements(androidx.security.crypto.EncryptedSharedPreferences::class)

--- a/shared/src/test/java/com/example/mymediaplayer/shared/EncryptedPrefsManagerTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/EncryptedPrefsManagerTest.kt
@@ -38,7 +38,7 @@ class EncryptedPrefsManagerTest {
     @Implements(androidx.security.crypto.MasterKey.Builder::class)
     class ShadowMasterKeyBuilder {
         @org.robolectric.annotation.RealObject
-        lateinit var realObject: androidx.security.crypto.MasterKey.Builder
+        private lateinit var realObject: androidx.security.crypto.MasterKey.Builder
 
         @Implementation
         fun __constructor__(context: Context) {
@@ -52,7 +52,8 @@ class EncryptedPrefsManagerTest {
         @Implementation
         fun build(): androidx.security.crypto.MasterKey {
             val cls = androidx.security.crypto.MasterKey::class.java
-            val constructor = cls.declaredConstructors.first()
+            val constructor = cls.declaredConstructors.firstOrNull { it.parameterTypes.size == 3 }
+                 ?: cls.declaredConstructors.first()
             constructor.isAccessible = true
 
             val params = constructor.parameterTypes
@@ -70,7 +71,12 @@ class EncryptedPrefsManagerTest {
 
     @Before
     fun setup() {
-        EncryptedPrefsManager.clearCacheForTesting()
+        // Use reflection to clear the cache instead to ensure test isolation
+        // without relying on clearCacheForTesting.
+        val field = EncryptedPrefsManager::class.java.getDeclaredField("prefsInstances")
+        field.isAccessible = true
+        val map = field.get(EncryptedPrefsManager) as java.util.concurrent.ConcurrentHashMap<*, *>
+        map.clear()
     }
 
     @Test


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the missing test file for EncryptedPrefsManager.kt.
📊 **Coverage:** The test coverage now includes the creation, retrieval, and caching mechanisms of EncryptedSharedPreferences.
✨ **Result:** The test suite now confidently validates the singletons instance creation logic while sidestepping flaky Robolectric AndroidKeyStore limitations via a clean shadow implementation for EncryptedSharedPreferences and bypassing MasterKey internal keystore access.

---
*PR created automatically by Jules for task [14758595956509703385](https://jules.google.com/task/14758595956509703385) started by @kimptoc*