### PR TITLE
🧪 [testing improvement] Add missing test for null object reference in MediaMetadataHelper

### DIFF
--- a/shared/src/test/java/com/example/mymediaplayer/shared/MediaMetadataHelperTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/MediaMetadataHelperTest.kt
@@ -97,4 +97,21 @@ class MediaMetadataHelperTest {
         val warningLog = logs.find { it.type == android.util.Log.WARN && it.msg == "No ID3 tags found for media" }
         org.junit.Assert.assertNotNull("Expected warning log for missing ID3 tags was not found", warningLog)
     }
+
+    @Test
+    fun extractMetadata_whenRetrieverThrowsNullPointerException_returnsNull() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val uriString = "content://something/npe"
+        val uri = Uri.parse(uriString)
+
+        // Configure ShadowMediaMetadataRetriever to throw a NullPointerException
+        // to simulate an error occurring inside the try-catch block
+        val dataSource = DataSource.toDataSource(context, uri)
+        ShadowMediaMetadataRetriever.addException(dataSource, java.lang.NullPointerException("Simulated null object reference"))
+
+        val result = MediaMetadataHelper.extractMetadata(context, uriString)
+
+        // The exception caught block should catch NPE and return null
+        assertNull(result)
+    }
 }


### PR DESCRIPTION
🎯 **What:** Added a missing unit test for `MediaMetadataHelper.extractMetadata` to explicitly verify that a `NullPointerException` thrown from the underlying `MediaMetadataRetriever` (e.g. from a null object reference) is correctly caught within the try-catch block and handled gracefully by returning `null`.
📊 **Coverage:** The new test explicitly covers the error-path scenario where a `NullPointerException` is thrown during metadata extraction inside the try block, ensuring robust error handling.
✨ **Result:** Test coverage for `MediaMetadataHelper` is improved, verifying the application does not crash when unexpected null object references occur in the media retriever layer.

---
*PR created automatically by Jules for task [4477697452566413673](https://jules.google.com/task/4477697452566413673) started by @kimptoc*