### PR TITLE
feat(shared): implement cache staleness check for external media

### DIFF
--- a/shared/src/main/java/com/example/mymediaplayer/shared/MediaCacheService.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/MediaCacheService.kt
@@ -545,7 +545,7 @@ class MediaCacheService {
         dao.replacePlaylists(playlists)
     }
 
-    fun persistCache(context: Context, treeUri: Uri, maxFiles: Int) {
+    fun persistCache(context: Context, treeUri: Uri, maxFiles: Int, scannedAt: Long = System.currentTimeMillis()) {
         val db = MediaCacheDatabase.getInstance(context)
         val dao = db.cacheDao()
         val files = synchronized(cacheLock) { _cachedFiles.toList() }.map {
@@ -571,7 +571,7 @@ class MediaCacheService {
         val state = ScanStateEntity(
             treeUri = treeUri.toString(),
             scanLimit = maxFiles,
-            scannedAt = System.currentTimeMillis()
+            scannedAt = scannedAt
         )
         dao.replaceCache(files, playlists, state)
     }
@@ -966,8 +966,9 @@ class MediaCacheService {
             null,
             "${MediaStore.Audio.Media.DATE_ADDED} DESC"
         )?.use { cursor ->
-            if (cursor.moveToFirst() && !cursor.isNull(0)) {
-                val latestSeconds = cursor.getLong(0)
+            val col = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.DATE_ADDED)
+            if (cursor.moveToFirst() && !cursor.isNull(col)) {
+                val latestSeconds = cursor.getLong(col)
                 if (latestSeconds > 0) {
                     val latestMs = latestSeconds * 1000L
                     if (latestMs > scannedAt) return true

--- a/shared/src/main/java/com/example/mymediaplayer/shared/MediaCacheService.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/MediaCacheService.kt
@@ -498,6 +498,9 @@ class MediaCacheService {
         if (state.treeUri != treeUri.toString() || state.scanLimit != maxFiles) {
             return null
         }
+        if (treeUri == MediaStore.Audio.Media.EXTERNAL_CONTENT_URI && isCacheStaleForWholeDevice(context, state.scannedAt)) {
+            return null
+        }
         val files = dao.getAllFiles().map {
             val decodedUri = Uri.decode(it.uriString)
             val genre = it.genre ?: normalizeGenre(inferGenreFromPath(decodedUri))
@@ -952,6 +955,26 @@ class MediaCacheService {
         if (year == null || year <= 0) return UNKNOWN_DECADE
         val decade = (year / 10) * 10
         return "${decade}s"
+    }
+
+    private fun isCacheStaleForWholeDevice(context: Context, scannedAt: Long): Boolean {
+        val projection = arrayOf(MediaStore.Audio.Media.DATE_ADDED)
+        context.contentResolver.query(
+            MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
+            projection,
+            "${MediaStore.Audio.Media.IS_MUSIC} != 0",
+            null,
+            "${MediaStore.Audio.Media.DATE_ADDED} DESC"
+        )?.use { cursor ->
+            if (cursor.moveToFirst() && !cursor.isNull(0)) {
+                val latestSeconds = cursor.getLong(0)
+                if (latestSeconds > 0) {
+                    val latestMs = latestSeconds * 1000L
+                    if (latestMs > scannedAt) return true
+                }
+            }
+        }
+        return false
     }
 
 }

--- a/shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
@@ -1416,6 +1416,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
                             notifyChildrenChanged(SONGS_ALL_ID)
                         }
                     }
+                    val scanStartedAt = System.currentTimeMillis()
                     if (wholeDriveMode) {
                         mediaCacheService.scanWholeDevice(this@MyMusicService, limit, progress)
                     } else {
@@ -1430,7 +1431,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
                         mediaCacheService.enrichGenresFromMediaStore(this@MyMusicService)
                     }
                     mediaCacheService.buildAlbumArtistIndexesFromCache()
-                    mediaCacheService.persistCache(this@MyMusicService, uri, limit)
+                    mediaCacheService.persistCache(this@MyMusicService, uri, limit, scanStartedAt)
                 }
             } finally {
                 isScanning = false


### PR DESCRIPTION
## Summary

- Adds a staleness check to `MediaCacheService` that compares the last scanned timestamp against the most recently added media file in MediaStore
- Prevents returning stale cached results when new music has been added to the device
- Fixes the shuffle list not updating after new songs are added (#307)

## Test plan

- [ ] Add songs to the device, then open the app and verify new songs appear in shuffle/genre lists
- [ ] Verify cached results are still used when no new media has been added (no regression in scan performance)
- [ ] Check that a media scan followed by genre browsing picks up newly added songs

Closes #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)