### PR TITLE
fix(shared): timeout MediaMetadataRetriever to unblock SAF scan during playback

### DIFF
--- a/shared/src/main/java/com/example/mymediaplayer/shared/MediaCacheService.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/MediaCacheService.kt
@@ -11,6 +11,8 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.isActive
+import kotlinx.coroutines.runInterruptible
+import kotlinx.coroutines.withTimeoutOrNull
 import java.time.Instant
 import java.time.ZoneId
 import java.util.Locale
@@ -39,6 +41,9 @@ class MediaCacheService {
         private const val UNKNOWN_DECADE = "Unknown Decade"
         private const val METADATA_BATCH_SIZE = 50
         private const val METADATA_PARALLELISM = 4
+        // MediaMetadataRetriever.setDataSource can block indefinitely when MediaPlayer holds
+        // the hardware codec. This timeout lets the batch continue with filename fallback.
+        private const val METADATA_EXTRACT_TIMEOUT_MS = 2000L
         private val SUPPORTED_AUDIO_EXTENSIONS = setOf(
             ".mp3", ".m4a", ".aac", ".flac", ".ogg", ".opus", ".wav", ".m4b",
             ".aiff", ".aif", ".wma", ".alac", ".ape", ".amr", ".awb",
@@ -440,8 +445,12 @@ class MediaCacheService {
         return probedCandidates
     }
 
-    private fun extractCandidateMetadata(context: Context, candidate: FileCandidate): MediaFileInfo? {
-        val metadata = MediaMetadataHelper.extractMetadata(context, candidate.uri.toString())
+    private suspend fun extractCandidateMetadata(context: Context, candidate: FileCandidate): MediaFileInfo? {
+        val metadata = withTimeoutOrNull(METADATA_EXTRACT_TIMEOUT_MS) {
+            runInterruptible(Dispatchers.IO) {
+                MediaMetadataHelper.extractMetadata(context, candidate.uri.toString())
+            }
+        }
         if (candidate.requiresProbe) {
             if (!looksLikeAudioMetadata(metadata)) {
                 return null


### PR DESCRIPTION
## Summary

- `MediaMetadataRetriever.setDataSource` competes for hardware codec resources with `MediaPlayer` — when a song is playing, all 4 parallel metadata extractors block indefinitely
- This caused the SAF folder scan to freeze at \"0 scanned\" until the playing song ended
- Wraps the extraction call in `withTimeoutOrNull(2s)` + `runInterruptible(Dispatchers.IO)` so a blocked call is abandoned after 2 seconds
- On timeout, `metadata` is `null` — for known audio extensions the file is still added with filename-based title; for unknown extensions it is skipped (can't confirm audio without metadata)
- Scan now makes continuous forward progress even while music is playing

## Test plan

- [ ] Start a SAF folder scan while a song is playing — verify progress increments rather than staying at 0
- [ ] Confirm scanned files appear with correct metadata when no playback contention
- [ ] Confirm files timed out during playback get filename-based titles (no tags) and are still included in the library
- [ ] Run unit tests: `./gradlew :shared:testDebugUnitTest`

Closes #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)