### PR TITLE
fix(shared): handle EncryptedSharedPreferences creation failures

### DIFF
--- a/shared/src/main/java/com/example/mymediaplayer/shared/EncryptedPrefsManager.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/EncryptedPrefsManager.kt
@@ -7,6 +7,7 @@ import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
 import java.io.IOException
 import java.security.GeneralSecurityException
+import java.util.Collections
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -14,7 +15,9 @@ import java.util.concurrent.ConcurrentHashMap
  */
 object EncryptedPrefsManager {
     private const val TAG = "EncryptedPrefsManager"
-    private val prefsInstances = ConcurrentHashMap<String, SharedPreferences?>()
+    private val prefsInstances = ConcurrentHashMap<String, SharedPreferences>()
+    // ConcurrentHashMap does not support null values, so failures are tracked separately.
+    private val failedFileNames: MutableSet<String> = Collections.newSetFromMap(ConcurrentHashMap())
 
     /**
      * Creates or retrieves an EncryptedSharedPreferences instance for the given file name.
@@ -22,13 +25,11 @@ object EncryptedPrefsManager {
      * after OS updates or keystore corruption).
      */
     fun createOrGet(context: Context, fileName: String): SharedPreferences? {
-        val cached = prefsInstances[fileName]
-        if (cached != null) return cached
-        // Check if we already tried and failed (null value cached)
-        if (prefsInstances.containsKey(fileName)) return null
+        prefsInstances[fileName]?.let { return it }
+        if (failedFileNames.contains(fileName)) return null
         return synchronized(prefsInstances) {
-            val existing = prefsInstances[fileName]
-            if (existing != null) return@synchronized existing
+            prefsInstances[fileName]?.let { return@synchronized it }
+            if (failedFileNames.contains(fileName)) return@synchronized null
             try {
                 val masterKey = MasterKey.Builder(context)
                     .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
@@ -42,11 +43,11 @@ object EncryptedPrefsManager {
                 ).also { prefsInstances[fileName] = it }
             } catch (e: GeneralSecurityException) {
                 Log.e(TAG, "Failed to create EncryptedSharedPreferences for $fileName", e)
-                prefsInstances[fileName] = null
+                failedFileNames.add(fileName)
                 null
             } catch (e: IOException) {
                 Log.e(TAG, "Failed to create EncryptedSharedPreferences for $fileName", e)
-                prefsInstances[fileName] = null
+                failedFileNames.add(fileName)
                 null
             }
         }
@@ -54,5 +55,6 @@ object EncryptedPrefsManager {
 
     fun clearCacheForTesting() {
         prefsInstances.clear()
+        failedFileNames.clear()
     }
 }

--- a/shared/src/main/java/com/example/mymediaplayer/shared/EncryptedPrefsManager.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/EncryptedPrefsManager.kt
@@ -2,6 +2,7 @@ package com.example.mymediaplayer.shared
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.util.Log
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
 import java.util.concurrent.ConcurrentHashMap
@@ -10,25 +11,38 @@ import java.util.concurrent.ConcurrentHashMap
  * Utility singleton for managing EncryptedSharedPreferences instances.
  */
 object EncryptedPrefsManager {
-    private val prefsInstances = ConcurrentHashMap<String, SharedPreferences>()
+    private const val TAG = "EncryptedPrefsManager"
+    private val prefsInstances = ConcurrentHashMap<String, SharedPreferences?>()
 
     /**
      * Creates or retrieves an EncryptedSharedPreferences instance for the given file name.
+     * Returns null if the Android Keystore is unavailable (e.g., on some Samsung devices
+     * after OS updates or keystore corruption).
      */
-    fun createOrGet(context: Context, fileName: String): SharedPreferences {
-        // Look up first before doing any Keystore initialization to avoid failure
-        // in tests where we are mimicking failure by overriding context.
-        return prefsInstances.computeIfAbsent(fileName) {
-            val masterKey = MasterKey.Builder(context)
-                .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
-                .build()
-            EncryptedSharedPreferences.create(
-                context,
-                fileName,
-                masterKey,
-                EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
-            )
+    fun createOrGet(context: Context, fileName: String): SharedPreferences? {
+        val cached = prefsInstances[fileName]
+        if (cached != null) return cached
+        // Check if we already tried and failed (null value cached)
+        if (prefsInstances.containsKey(fileName)) return null
+        return synchronized(prefsInstances) {
+            val existing = prefsInstances[fileName]
+            if (existing != null) return@synchronized existing
+            try {
+                val masterKey = MasterKey.Builder(context)
+                    .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+                    .build()
+                EncryptedSharedPreferences.create(
+                    context,
+                    fileName,
+                    masterKey,
+                    EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+                    EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+                ).also { prefsInstances[fileName] = it }
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to create EncryptedSharedPreferences for $fileName — keystore unavailable", e)
+                prefsInstances[fileName] = null
+                null
+            }
         }
     }
 

--- a/shared/src/main/java/com/example/mymediaplayer/shared/EncryptedPrefsManager.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/EncryptedPrefsManager.kt
@@ -5,6 +5,8 @@ import android.content.SharedPreferences
 import android.util.Log
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
+import java.io.IOException
+import java.security.GeneralSecurityException
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -38,8 +40,12 @@ object EncryptedPrefsManager {
                     EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
                     EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
                 ).also { prefsInstances[fileName] = it }
-            } catch (e: Exception) {
-                Log.e(TAG, "Failed to create EncryptedSharedPreferences for $fileName — keystore unavailable", e)
+            } catch (e: GeneralSecurityException) {
+                Log.e(TAG, "Failed to create EncryptedSharedPreferences for $fileName", e)
+                prefsInstances[fileName] = null
+                null
+            } catch (e: IOException) {
+                Log.e(TAG, "Failed to create EncryptedSharedPreferences for $fileName", e)
                 prefsInstances[fileName] = null
                 null
             }

--- a/shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
@@ -120,34 +120,43 @@ class MyMusicService : MediaBrowserServiceCompat() {
             if (existingPrefs != null) { return existingPrefs }
             val encryptedPrefs = EncryptedPrefsManager.createOrGet(context, "${PREFS_NAME}_encrypted")
             val standardPrefsFile = File(context.applicationInfo.dataDir, "shared_prefs/${PREFS_NAME}.xml")
-            if (standardPrefsFile.exists() && !encryptedPrefs.getBoolean("migration_completed", false)) {
-                val standardPrefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-                val editor = encryptedPrefs.edit()
-                for ((key, value) in standardPrefs.all) {
-                    when (value) {
-                        is String -> editor.putString(key, value)
-                        is Int -> editor.putInt(key, value)
-                        is Boolean -> editor.putBoolean(key, value)
-                        is Long -> editor.putLong(key, value)
-                        is Float -> editor.putFloat(key, value)
-                        is Set<*> -> {
-                            @Suppress("UNCHECKED_CAST")
-                            editor.putStringSet(key, value as Set<String>)
+            val standardPrefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+            if (encryptedPrefs != null) {
+                if (standardPrefsFile.exists() && !encryptedPrefs.getBoolean("migration_completed", false)) {
+                    val editor = encryptedPrefs.edit()
+                    for ((key, value) in standardPrefs.all) {
+                        when (value) {
+                            is String -> editor.putString(key, value)
+                            is Int -> editor.putInt(key, value)
+                            is Boolean -> editor.putBoolean(key, value)
+                            is Long -> editor.putLong(key, value)
+                            is Float -> editor.putFloat(key, value)
+                            is Set<*> -> {
+                                @Suppress("UNCHECKED_CAST")
+                                editor.putStringSet(key, value as Set<String>)
+                            }
                         }
                     }
+                    try {
+                        @Suppress("ApplySharedPref")
+                        editor.putBoolean("migration_completed", true).commit()
+                        @Suppress("ApplySharedPref")
+                        standardPrefs.edit().clear().commit()
+                        standardPrefsFile.delete()
+                    } catch (e: Exception) {
+                        // Log error - migration will retry on next app launch
+                    }
                 }
-                try {
-                    @Suppress("ApplySharedPref")
-                    editor.putBoolean("migration_completed", true).commit()
-                    @Suppress("ApplySharedPref")
-                    standardPrefs.edit().clear().commit()
-                    standardPrefsFile.delete()
-                } catch (e: Exception) {
-                    // Log error - migration will retry on next app launch
-                }
+                prefsInstance = encryptedPrefs
+                return encryptedPrefs
             }
-            prefsInstance = encryptedPrefs
-            return encryptedPrefs
+
+            // Keystore unavailable — fall back to standard (unencrypted) preferences.
+            // If a migration was previously completed, the standard prefs will be empty;
+            // the user will just need to reconfigure settings.
+            prefsInstance = standardPrefs
+            return standardPrefs
         }
         private const val ACTION_MEDIA_PLAY_FROM_SEARCH = "android.media.action.MEDIA_PLAY_FROM_SEARCH"
 

--- a/shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
@@ -145,7 +145,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
                         standardPrefs.edit().clear().commit()
                         standardPrefsFile.delete()
                     } catch (e: Exception) {
-                        // Log error - migration will retry on next app launch
+                        Log.e("MyMusicService", "Failed to commit prefs migration for $PREFS_NAME — will retry on next launch", e)
                     }
                 }
                 prefsInstance = encryptedPrefs

--- a/shared/src/test/java/com/example/mymediaplayer/shared/ApiKeyStoreTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/ApiKeyStoreTest.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -15,6 +16,11 @@ import java.security.GeneralSecurityException
 
 @RunWith(RobolectricTestRunner::class)
 class ApiKeyStoreTest {
+
+    @Before
+    fun setup() {
+        EncryptedPrefsManager.clearCacheForTesting()
+    }
 
     @Test
     fun getPrefs_success_returnsSharedPreferences() {

--- a/shared/src/test/java/com/example/mymediaplayer/shared/EncryptedPrefsManagerTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/EncryptedPrefsManagerTest.kt
@@ -17,7 +17,6 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.Implementation
 import org.robolectric.annotation.Implements
-import java.util.concurrent.ConcurrentHashMap
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [34], shadows = [EncryptedPrefsManagerTest.ShadowEncryptedSharedPreferences::class, EncryptedPrefsManagerTest.ShadowMasterKeyBuilder::class])
@@ -73,10 +72,7 @@ class EncryptedPrefsManagerTest {
 
     @Before
     fun setup() {
-        val field = EncryptedPrefsManager::class.java.getDeclaredField("prefsInstances")
-        field.isAccessible = true
-        val map = field.get(EncryptedPrefsManager) as ConcurrentHashMap<*, *>
-        map.clear()
+        EncryptedPrefsManager.clearCacheForTesting()
     }
 
     @Test

--- a/shared/src/test/java/com/example/mymediaplayer/shared/EncryptedPrefsManagerTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/EncryptedPrefsManagerTest.kt
@@ -116,7 +116,7 @@ class EncryptedPrefsManagerTest {
     @Test
     fun testPutAndGet() {
         val context = ApplicationProvider.getApplicationContext<Context>()
-        val prefs = EncryptedPrefsManager.createOrGet(context, "test_prefs")
+        val prefs = requireNotNull(EncryptedPrefsManager.createOrGet(context, "test_prefs"))
 
         prefs.edit().putString("key", "value").commit()
         assertEquals("value", prefs.getString("key", null))

--- a/shared/src/test/java/com/example/mymediaplayer/shared/EncryptedPrefsManagerTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/EncryptedPrefsManagerTest.kt
@@ -104,7 +104,7 @@ class EncryptedPrefsManagerTest {
         // Verify the internal prefsInstances map is actually cleared
         val field = EncryptedPrefsManager::class.java.getDeclaredField("prefsInstances")
         field.isAccessible = true
-        val map = field.get(EncryptedPrefsManager) as ConcurrentHashMap<*, *>
+        val map = field.get(EncryptedPrefsManager) as Map<*, *>
 
         assertTrue(map.isEmpty())
     }


### PR DESCRIPTION
## Summary

- `EncryptedSharedPreferences.create()` can throw on some devices (notably Samsung after OS updates or keystore corruption) when the Android Keystore is unavailable
- This caused a hard crash on app launch (#310)
- `EncryptedPrefsManager.createOrGet` now wraps creation in a try/catch and returns `null` on failure
- `MyMusicService` falls back to standard (unencrypted) `SharedPreferences` when encrypted prefs are unavailable — the user will need to reconfigure settings, but the app no longer crashes
- Failed creation result is cached so the Keystore is not retried on every call

## Test plan

- [ ] Verify app launches normally on a device with a healthy Keystore
- [ ] Simulate Keystore failure — verify app falls back to standard prefs and does not crash
- [ ] Run unit tests: `./gradlew :shared:testDebugUnitTest`

Closes #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)