### PR TITLE
fix: emit STATE_ERROR (not STATE_STOPPED) when playback fails unrecoverably

### DIFF
--- a/shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
@@ -1905,8 +1905,8 @@ class MyMusicService : MediaBrowserServiceCompat() {
         consecutivePlaybackErrors += 1
         if (!shouldRetryPlaybackError(consecutivePlaybackErrors, MAX_CONSECUTIVE_PLAYBACK_ERRORS)) {
             Log.w("MyMusicService", "Too many consecutive playback errors, stopping recovery")
-            teardownPlayer()
             updatePlaybackState(PlaybackStateCompat.STATE_ERROR, errorMessage = message)
+            teardownPlayer()
             consecutivePlaybackErrors = 0
             return
         }
@@ -1919,6 +1919,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
         Log.w("MyMusicService", "Unable to recover playback error: $message")
         updatePlaybackState(PlaybackStateCompat.STATE_ERROR, errorMessage = message)
         teardownPlayer()
+        consecutivePlaybackErrors = 0
     }
 
     private fun peekNextQueueTrack(): MediaFileInfo? {

--- a/shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
@@ -1905,7 +1905,8 @@ class MyMusicService : MediaBrowserServiceCompat() {
         consecutivePlaybackErrors += 1
         if (!shouldRetryPlaybackError(consecutivePlaybackErrors, MAX_CONSECUTIVE_PLAYBACK_ERRORS)) {
             Log.w("MyMusicService", "Too many consecutive playback errors, stopping recovery")
-            handleStop()
+            teardownPlayer()
+            updatePlaybackState(PlaybackStateCompat.STATE_ERROR, errorMessage = message)
             consecutivePlaybackErrors = 0
             return
         }
@@ -1917,7 +1918,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
         }
         Log.w("MyMusicService", "Unable to recover playback error: $message")
         updatePlaybackState(PlaybackStateCompat.STATE_ERROR, errorMessage = message)
-        handleStop()
+        teardownPlayer()
     }
 
     private fun peekNextQueueTrack(): MediaFileInfo? {
@@ -2633,14 +2634,18 @@ class MyMusicService : MediaBrowserServiceCompat() {
         }
     }
 
-    private fun handleStop() {
+    private fun teardownPlayer() {
         resumeOnAudioFocusGain = false
         val lastPosition = currentPositionSafeMs()
         releaseMediaPlayer()
         abandonAudioFocus()
+        savePlaybackSnapshot(positionMsOverride = lastPosition)
+    }
+
+    private fun handleStop() {
+        teardownPlayer()
         updatePlaybackState(PlaybackStateCompat.STATE_STOPPED)
         consecutivePlaybackErrors = 0
-        savePlaybackSnapshot(positionMsOverride = lastPosition)
     }
 
     private fun updatePlaybackState(state: Int, errorMessage: String? = null) {

--- a/shared/src/test/java/com/example/mymediaplayer/shared/MyMusicServicePlaybackErrorTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/MyMusicServicePlaybackErrorTest.kt
@@ -64,7 +64,7 @@ class MyMusicServicePlaybackErrorTest {
 
         // The queue index advanced, proving the advance branch was taken (not error-state path)
         val queueIndex = getQueueIndex(service)
-        assertEquals(true, queueIndex >= 1)
+        assertEquals(1, queueIndex)
     }
 
     private fun setConsecutiveErrors(service: MyMusicService, count: Int) {

--- a/shared/src/test/java/com/example/mymediaplayer/shared/MyMusicServicePlaybackErrorTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/MyMusicServicePlaybackErrorTest.kt
@@ -1,0 +1,93 @@
+package com.example.mymediaplayer.shared
+
+import android.support.v4.media.session.MediaControllerCompat
+import android.support.v4.media.session.PlaybackStateCompat
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class MyMusicServicePlaybackErrorTest {
+
+    @Before
+    fun setup() {
+        EncryptedPrefsManager.clearCacheForTesting()
+    }
+
+    // When the consecutive-error budget is exhausted, Android Auto must see STATE_ERROR
+    // so it shows a failure message rather than spinning forever.
+    @Test
+    fun handlePlaybackError_whenBudgetExhausted_emitsStateError() {
+        val service = Robolectric.buildService(MyMusicService::class.java).create().get()
+        setConsecutiveErrors(service, 2) // one more call makes it 3 = MAX, triggering giveup
+
+        service.handlePlaybackError("all retries exhausted")
+
+        val state = MediaControllerCompat(service, service.sessionToken!!).playbackState?.state
+        assertEquals(PlaybackStateCompat.STATE_ERROR, state)
+    }
+
+    // When there's nothing left in the queue to advance to, the same STATE_ERROR must persist —
+    // handleStop() must not overwrite it with STATE_STOPPED.
+    @Test
+    fun handlePlaybackError_whenQueueExhausted_emitsStateError() {
+        val service = Robolectric.buildService(MyMusicService::class.java).create().get()
+        // consecutivePlaybackErrors = 0 (default), playlistQueue = empty (default)
+        // → budget not exhausted, but advanceQueueOnError() returns false
+
+        service.handlePlaybackError("no tracks left in queue")
+
+        val state = MediaControllerCompat(service, service.sessionToken!!).playbackState?.state
+        assertEquals(PlaybackStateCompat.STATE_ERROR, state)
+    }
+
+    // Regression: when queue can advance, the advance path is taken (not the error-state path).
+    @Test
+    fun handlePlaybackError_whenQueueAdvances_advancesQueueIndex() {
+        val service = Robolectric.buildService(MyMusicService::class.java).create().get()
+        service.mediaCacheService.addFile(
+            MediaFileInfo(uriString = "content://test/1", displayName = "a.mp3", sizeBytes = 1L)
+        )
+        service.mediaCacheService.addFile(
+            MediaFileInfo(uriString = "content://test/2", displayName = "b.mp3", sizeBytes = 1L)
+        )
+        setPlaylistQueue(service, service.mediaCacheService.cachedFiles)
+        setQueueIndex(service, 0)
+        // queue has 2 tracks at index 0; advanceQueueOnError() should move to index 1
+
+        service.handlePlaybackError("transient error, queue can advance")
+
+        // The queue index advanced, proving the advance branch was taken (not error-state path)
+        val queueIndex = getQueueIndex(service)
+        assertEquals(true, queueIndex >= 1)
+    }
+
+    private fun setConsecutiveErrors(service: MyMusicService, count: Int) {
+        val field = MyMusicService::class.java.getDeclaredField("consecutivePlaybackErrors")
+        field.isAccessible = true
+        field.set(service, count)
+    }
+
+    private fun setPlaylistQueue(service: MyMusicService, tracks: List<MediaFileInfo>) {
+        val field = MyMusicService::class.java.getDeclaredField("playlistQueue")
+        field.isAccessible = true
+        field.set(service, tracks)
+    }
+
+    private fun setQueueIndex(service: MyMusicService, index: Int) {
+        val field = MyMusicService::class.java.getDeclaredField("currentQueueIndex")
+        field.isAccessible = true
+        field.setInt(service, index)
+    }
+
+    private fun getQueueIndex(service: MyMusicService): Int {
+        val field = MyMusicService::class.java.getDeclaredField("currentQueueIndex")
+        field.isAccessible = true
+        return field.getInt(service)
+    }
+}


### PR DESCRIPTION
## Summary

- Extracts `teardownPlayer()` from `handleStop()` to separate cleanup (release player, abandon audio focus, save snapshot) from state-setting
- Fixes budget-exhausted error path: was calling `handleStop()` which emits `STATE_STOPPED`; now calls `teardownPlayer()` then `updatePlaybackState(STATE_ERROR)`
- Fixes queue-exhausted error path: was calling `updatePlaybackState(STATE_ERROR)` then `handleStop()` which immediately overwrote it with `STATE_STOPPED`; now calls `teardownPlayer()` instead
- Adds `MyMusicServicePlaybackErrorTest` with three Robolectric tests covering both error paths and the normal queue-advance case

## Why it matters

Android Auto renders `STATE_STOPPED` as a spinner (users wait forever) but `STATE_ERROR` as an actionable error message. Without this fix, when all retries fail, AA appears hung.

Fixes #244

## Test plan

- [x] `handlePlaybackError_whenBudgetExhausted_emitsStateError` — was RED (expected 7, got 1), now GREEN
- [x] `handlePlaybackError_whenQueueExhausted_emitsStateError` — was RED (expected 7, got 1), now GREEN
- [x] `handlePlaybackError_whenQueueAdvances_advancesQueueIndex` — queue-advance path still works
- [x] Full shared test suite passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)