### PR TITLE
🧪 Add edge case tests and fix bug in String.fileExtension()

### DIFF
--- a/shared/src/main/java/com/example/mymediaplayer/shared/StringExt.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/StringExt.kt
@@ -7,7 +7,7 @@ import java.util.Locale
  * including the dot (e.g., ".mp3"), or "(none)" if no extension is found.
  */
 fun String.fileExtension(): String {
-    val filename = this.substringAfterLast('/')
+    val filename = this.substringAfterLast('/').substringAfterLast('\\')
     val ext = filename.substringAfterLast('.', "")
     return if (ext.isNotEmpty()) ".$ext".lowercase(Locale.US) else "(none)"
 }

--- a/shared/src/main/java/com/example/mymediaplayer/shared/StringExt.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/StringExt.kt
@@ -7,6 +7,7 @@ import java.util.Locale
  * including the dot (e.g., ".mp3"), or "(none)" if no extension is found.
  */
 fun String.fileExtension(): String {
-    val ext = this.substringAfterLast('.', "")
+    val filename = this.substringAfterLast('/')
+    val ext = filename.substringAfterLast('.', "")
     return if (ext.isNotEmpty()) ".$ext".lowercase(Locale.US) else "(none)"
 }

--- a/shared/src/test/java/com/example/mymediaplayer/shared/StringExtTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/StringExtTest.kt
@@ -30,5 +30,10 @@ class StringExtTest {
         assertEquals("(none)", "some.dir/file.".fileExtension())
         assertEquals(".txt", "some.dir/file.txt".fileExtension())
         assertEquals(".gz", "archive.tar.gz".fileExtension())
+
+        // Backslash paths (Windows-style)
+        assertEquals("(none)", "some.dir\\file".fileExtension())
+        assertEquals(".txt", "some.dir\\file.txt".fileExtension())
+        assertEquals(".mp3", "C:\\Music\\some.album\\track.mp3".fileExtension())
     }
 }

--- a/shared/src/test/java/com/example/mymediaplayer/shared/StringExtTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/StringExtTest.kt
@@ -13,4 +13,22 @@ class StringExtTest {
         assertEquals(".jpg", "file.NAME.JPG".fileExtension())
         assertEquals(".mp4", "some/path.to/file.mp4".fileExtension())
     }
+
+    @Test
+    fun fileExtension_edgeCases() {
+        // Empty and basic
+        assertEquals("(none)", "".fileExtension())
+        assertEquals("(none)", ".".fileExtension())
+        assertEquals("(none)", "..".fileExtension())
+
+        // Multiple dots
+        assertEquals(".txt", ".hidden.txt".fileExtension())
+        assertEquals(".d", "a.b.c.d".fileExtension())
+
+        // Paths
+        assertEquals("(none)", "some.dir/file".fileExtension())
+        assertEquals("(none)", "some.dir/file.".fileExtension())
+        assertEquals(".txt", "some.dir/file.txt".fileExtension())
+        assertEquals(".gz", "archive.tar.gz".fileExtension())
+    }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is missing edge case tests for String.fileExtension(), particularly with dots in paths and empty inputs. Also fixed a bug found where a dot in the directory path of a file with no extension incorrectly returns the directory dot as the file extension.
📊 **Coverage:** Empty strings, basic dots, multiple dots in filename, multiple extensions, file paths with dots in the directory but no extension on the file.
✨ **Result:** Improved test coverage and reliability for string extension extraction, fixed a bug.

---
*PR created automatically by Jules for task [17691076490990771704](https://jules.google.com/task/17691076490990771704) started by @kimptoc*