### PR TITLE
🧹 [Code Health] Extract AlbumSearchHitCard from AlbumSearchResultsSection

### DIFF
--- a/mobile/src/main/java/com/example/mymediaplayer/MainScreen.kt
+++ b/mobile/src/main/java/com/example/mymediaplayer/MainScreen.kt
@@ -1517,47 +1517,64 @@ private fun AlbumSearchResultsSection(
     Spacer(modifier = Modifier.height(8.dp))
     LazyColumn {
         items(albumHits) { hit ->
-            val allFavorited = hit.songs.isNotEmpty() &&
-                hit.songs.all { it.uriString in favoriteUris }
-            Card(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = 4.dp),
-                colors = CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.secondaryContainer
-                )
-            ) {
-                Column(modifier = Modifier.padding(12.dp)) {
-                    Text(
-                        text = hit.album,
-                        style = MaterialTheme.typography.titleSmall,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
-                    )
-                    Text(
-                        text = "${hit.matchedCount} matched • ${hit.songs.size} track(s)",
-                        style = MaterialTheme.typography.labelSmall
-                    )
-                    Spacer(modifier = Modifier.height(4.dp))
-                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                        TextButton(onClick = { onOpenAlbum(hit.album) }) {
-                            Text("Open")
-                        }
-                        TextButton(
-                            onClick = {
-                                toggleAlbumFavorite(hit.songs, favoriteUris, allFavorited, onToggleFavorite)
-                            },
-                            enabled = hit.songs.isNotEmpty()
-                        ) {
-                            Text(if (allFavorited) "Unfavorite album" else "Favorite album")
-                        }
-                        TextButton(
-                            onClick = { onAddAlbumToPlaylist(hit.songs) },
-                            enabled = hit.songs.isNotEmpty()
-                        ) {
-                            Text("Add album")
-                        }
-                    }
+            AlbumSearchHitCard(
+                hit = hit,
+                favoriteUris = favoriteUris,
+                onOpenAlbum = onOpenAlbum,
+                onAddAlbumToPlaylist = onAddAlbumToPlaylist,
+                onToggleFavorite = onToggleFavorite
+            )
+        }
+    }
+}
+
+@Composable
+private fun AlbumSearchHitCard(
+    hit: AlbumSearchHit,
+    favoriteUris: Set<String>,
+    onOpenAlbum: (String) -> Unit,
+    onAddAlbumToPlaylist: (List<MediaFileInfo>) -> Unit,
+    onToggleFavorite: (MediaFileInfo) -> Unit
+) {
+    val allFavorited = hit.songs.isNotEmpty() &&
+        hit.songs.all { it.uriString in favoriteUris }
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer
+        )
+    ) {
+        Column(modifier = Modifier.padding(12.dp)) {
+            Text(
+                text = hit.album,
+                style = MaterialTheme.typography.titleSmall,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            Text(
+                text = "${hit.matchedCount} matched • ${hit.songs.size} track(s)",
+                style = MaterialTheme.typography.labelSmall
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                TextButton(onClick = { onOpenAlbum(hit.album) }) {
+                    Text("Open")
+                }
+                TextButton(
+                    onClick = {
+                        toggleAlbumFavorite(hit.songs, favoriteUris, allFavorited, onToggleFavorite)
+                    },
+                    enabled = hit.songs.isNotEmpty()
+                ) {
+                    Text(if (allFavorited) "Unfavorite album" else "Favorite album")
+                }
+                TextButton(
+                    onClick = { onAddAlbumToPlaylist(hit.songs) },
+                    enabled = hit.songs.isNotEmpty()
+                ) {
+                    Text("Add album")
                 }
             }
         }


### PR DESCRIPTION
🎯 **What:** Extracted the deeply nested `Card` UI component inside the `LazyColumn` of `AlbumSearchResultsSection` into a separate `@Composable private fun AlbumSearchHitCard` component.
💡 **Why:** Deeply nested code inside Composables makes them harder to read and maintain. Extracting the list item content into a separate composable function improves readability, reduces indentation, and adheres to modularity best practices without altering behavior.
✅ **Verification:** Ran `./gradlew :mobile:testDebugUnitTest` and `./gradlew :shared:testDebugUnitTest` to ensure all tests continue to pass and no functionality was broken.
✨ **Result:** Improved readability and maintainability by eliminating the deeply nested code in `AlbumSearchResultsSection`.

---
*PR created automatically by Jules for task [8949507802615387115](https://jules.google.com/task/8949507802615387115) started by @kimptoc*