### PR TITLE
🧹 [code health improvement] Extract QueueItem from QueueDialogContent

### DIFF
--- a/mobile/src/main/java/com/example/mymediaplayer/MainScreen.kt
+++ b/mobile/src/main/java/com/example/mymediaplayer/MainScreen.kt
@@ -882,7 +882,12 @@ private fun RenamePlaylistDialogContent(
 
 @Composable
 private fun QueueItem(
+private fun QueueItem(
     item: QueueEntry,
+    activeQueueId: Long,
+    onQueueItemSelected: (Long) -> Unit,
+    modifier: Modifier = Modifier
+)
     activeQueueId: Long,
     onQueueItemSelected: (Long) -> Unit
 ) {

--- a/mobile/src/main/java/com/example/mymediaplayer/MainScreen.kt
+++ b/mobile/src/main/java/com/example/mymediaplayer/MainScreen.kt
@@ -884,16 +884,14 @@ private fun RenamePlaylistDialogContent(
 private fun QueueItem(
     item: QueueEntry,
     activeQueueId: Long,
-    onQueueItemSelected: (Long) -> Unit,
-    modifier: Modifier = Modifier
+    onQueueItemSelected: (Long) -> Unit
 ) {
     val isActive = item.queueId == activeQueueId
     TextButton(
         onClick = {
             onQueueItemSelected(item.queueId)
         },
-        enabled = !isActive,
-        modifier = modifier
+        enabled = !isActive
     ) {
         Text(
             text = if (isActive) "▶ ${item.title}" else item.title,

--- a/mobile/src/main/java/com/example/mymediaplayer/MainScreen.kt
+++ b/mobile/src/main/java/com/example/mymediaplayer/MainScreen.kt
@@ -881,6 +881,27 @@ private fun RenamePlaylistDialogContent(
 }
 
 @Composable
+private fun QueueItem(
+    item: QueueEntry,
+    activeQueueId: Long,
+    onQueueItemSelected: (Long) -> Unit
+) {
+    val isActive = item.queueId == activeQueueId
+    TextButton(
+        onClick = {
+            onQueueItemSelected(item.queueId)
+        },
+        enabled = !isActive
+    ) {
+        Text(
+            text = if (isActive) "▶ ${item.title}" else item.title,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+    }
+}
+
+@Composable
 private fun QueueDialogContent(
     queueTitle: String?,
     queueItems: List<QueueEntry>,
@@ -899,19 +920,11 @@ private fun QueueDialogContent(
             } else {
                 LazyColumn {
                     items(queueItems) { item ->
-                        val isActive = item.queueId == activeQueueId
-                        TextButton(
-                            onClick = {
-                                onQueueItemSelected(item.queueId)
-                            },
-                            enabled = !isActive
-                        ) {
-                            Text(
-                                text = if (isActive) "▶ ${item.title}" else item.title,
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis
-                            )
-                        }
+                        QueueItem(
+                            item = item,
+                            activeQueueId = activeQueueId,
+                            onQueueItemSelected = onQueueItemSelected
+                        )
                     }
                 }
             }

--- a/mobile/src/main/java/com/example/mymediaplayer/MainScreen.kt
+++ b/mobile/src/main/java/com/example/mymediaplayer/MainScreen.kt
@@ -882,21 +882,18 @@ private fun RenamePlaylistDialogContent(
 
 @Composable
 private fun QueueItem(
-private fun QueueItem(
     item: QueueEntry,
     activeQueueId: Long,
     onQueueItemSelected: (Long) -> Unit,
     modifier: Modifier = Modifier
-)
-    activeQueueId: Long,
-    onQueueItemSelected: (Long) -> Unit
 ) {
     val isActive = item.queueId == activeQueueId
     TextButton(
         onClick = {
             onQueueItemSelected(item.queueId)
         },
-        enabled = !isActive
+        enabled = !isActive,
+        modifier = modifier
     ) {
         Text(
             text = if (isActive) "▶ ${item.title}" else item.title,


### PR DESCRIPTION
🎯 **What:** Extracted the deeply nested `TextButton` inside `QueueDialogContent` into a separate `QueueItem` composable.
💡 **Why:** Reduces nesting, improving code readability and maintainability.
✅ **Verification:** Ran `git diff` to ensure accurate refactoring and executed `./gradlew :mobile:testDebugUnitTest` to confirm no regressions were introduced.
✨ **Result:** Improved code readability by abstracting logic into a specialized composable.

---
*PR created automatically by Jules for task [14348106831433547767](https://jules.google.com/task/14348106831433547767) started by @kimptoc*