### PR TITLE
Gate startForeground() on Android Auto bind (#246)

### DIFF
--- a/shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
@@ -204,6 +204,8 @@ class MyMusicService : MediaBrowserServiceCompat() {
         private const val NOW_PLAYING_CHANNEL_ID = "now_playing"
         private const val NOW_PLAYING_NOTIFICATION_ID = 1001
 
+        private const val ANDROID_AUTO_PACKAGE_NAME = "com.google.android.projection.gearhead"
+
         private const val EXTRA_MEDIA_FOCUS_KEY = "android.intent.extra.focus"
         private const val EXTRA_MEDIA_ARTIST_KEY = "android.intent.extra.artist"
         private const val EXTRA_MEDIA_ALBUM_KEY = "android.intent.extra.album"
@@ -255,6 +257,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
     private var consecutivePlaybackErrors: Int = 0
     @Volatile
     private var isScanning: Boolean = false
+    private var isForegroundPromoted: Boolean = false
     private val pendingResults =
         mutableMapOf<String, MutableList<MediaBrowserServiceCompat.Result<MutableList<MediaItem>>>>()
     private val mainHandler = Handler(Looper.getMainLooper())
@@ -667,17 +670,16 @@ class MyMusicService : MediaBrowserServiceCompat() {
         mark("restorePlaybackSnapshot done")
         loadCachedTreeIfAvailable()
         mark("loadCachedTreeIfAvailable returned (isScanning=$isScanning, cachedFiles=${mediaCacheService.cachedFiles.size})")
-        startForegroundReady()
-        mark("startForegroundReady done")
         mark("exit")
     }
 
-    // Promote the service to a foreground service the moment AA binds, so Android
-    // (and Samsung's "Freecess" aggressive freezer in particular) cannot freeze
-    // the process before the user's first play command arrives. Without this,
-    // gearhead's binder transactions to our MediaSession fail with error -32
-    // ("sent binder to frozen apps"), and AA's spinner ("getting your selection")
-    // hangs forever.
+    // Promote the service to a foreground service so Android (and Samsung's
+    // "Freecess" aggressive freezer in particular) cannot freeze the process
+    // before the user's first play command arrives. Without this, gearhead's
+    // binder transactions to our MediaSession fail with error -32 ("sent binder
+    // to frozen apps"), and AA's spinner ("getting your selection") hangs
+    // forever. Only called for AA connections (see onGetRoot) so phone-only
+    // sessions don't show a persistent "now playing" notification.
     private fun startForegroundReady() {
         runCatching {
             val notification = buildNowPlayingNotification(PlaybackStateCompat.STATE_NONE)
@@ -797,6 +799,11 @@ class MyMusicService : MediaBrowserServiceCompat() {
         rootHints: Bundle?
     ): MediaBrowserServiceCompat.BrowserRoot? {
         Log.d("MyMusicService", "onGetRoot from $clientPackageName uid=$clientUid")
+
+        if (clientPackageName == ANDROID_AUTO_PACKAGE_NAME && !isForegroundPromoted) {
+            startForegroundReady()
+            isForegroundPromoted = true
+        }
 
         val validator = PackageValidator(this)
         if (!validator.isCallerValid(clientPackageName, clientUid)) {


### PR DESCRIPTION
## Summary
- `startForegroundReady()` is no longer called unconditionally from `MyMusicService.onCreate`
- It's now called once, lazily, when `onGetRoot` is invoked by Android Auto's `gearhead` package — phone-only sessions never see a persistent "now playing" notification
- A new `isForegroundPromoted` flag ensures the promotion happens at most once per service instance

Closes #246

## Verification (on-device, Samsung S25 Ultra)
- **Phone-only launch**: `onGetRoot` from `com.example.mymediaplayer` does not trigger foreground promotion. `dumpsys activity services` shows `startForegroundCount=0`, and `dumpsys notification --noredact` shows no notification for the app.
- **Android Auto connection (via Desktop Head Unit)**: `onGetRoot` from `com.google.android.projection.gearhead` triggers foreground promotion exactly once. `dumpsys activity services` shows `startForegroundCount=1`. `dumpsys notification --noredact` shows the `now_playing` channel notification with the `FOREGROUND_SERVICE` flag. Library loads successfully (root browse items returned, 13634 cached files) with no `-32` ("sent binder to frozen apps") errors.
- **Mid-session AA connection**: Phone app launched fresh (no AA), then AA connected ~3s later — foreground promotion and notification still occur correctly on the delayed `onGetRoot`.

Note: the original bug's extended-idle Freecess freeze scenario couldn't be directly reproduced in this session (requires real device idle time), but the gating logic and AA connection path are confirmed working without binder errors.

## Test plan
- [x] `./gradlew :shared:testDebugUnitTest :mobile:testDebugUnitTest` — BUILD SUCCESSFUL
- [x] On-device verification (phone-only and Android Auto scenarios), see above