### PR TITLE
Enable largeHeap to mitigate startup OOM crash loop

### DIFF
--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:largeHeap="true"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.MyMediaPlayer"


### PR DESCRIPTION
## Summary
- Adds `android:largeHeap="true"` to the mobile app manifest as an immediate mitigation for a startup crash loop

## Background
Device logs from a Samsung S25 Ultra showed 40 `OutOfMemoryError` crashes in a tight loop (every ~20-40s), all at the default 256MB heap limit (`target footprint 268435456`), during `MyMusicService.loadCachedTreeIfAvailable()` while loading a 13,634-file persisted media cache:
- `MediaCacheService.kt:522` - `Uri.decode` per cached file in `loadPersistedCache`
- `MediaCacheService.kt:858` - `buildAlbumArtistIndexesFromCache` building 4 index maps over the full file list

## Follow-ups
Filed for the underlying memory pressure (not addressed in this PR):
- #335 - Reduce in-memory duplication in cache load/index build
- #336 - Avoid eager Uri.decode on every cached file during persisted cache load
- #337 - Add bitmap downsampling for embedded/folder album art

## Test plan
- [x] `./gradlew :mobile:processDebugManifest` succeeds
- [ ] Install on the affected S25 Ultra device and confirm the startup crash loop no longer occurs