### PR TITLE
Fix #326: Deep scan now caches results like a normal scan

### DIFF
--- a/mobile/src/main/java/com/example/mymediaplayer/MainScreen.kt
+++ b/mobile/src/main/java/com/example/mymediaplayer/MainScreen.kt
@@ -1139,7 +1139,7 @@ private fun ScanDialogContent(
                             checked = scanDeepMode,
                             onCheckedChange = onScanDeepModeChange
                         )
-                        Text("Deep scan (slower, tries unknown file types — disables startup cache, rescans every open)")
+                        Text("Deep scan (slower, tries unknown file types — result is cached for fast startups)")
                     }
                 }
                 Spacer(modifier = Modifier.height(4.dp))

--- a/mobile/src/main/java/com/example/mymediaplayer/MainViewModel.kt
+++ b/mobile/src/main/java/com/example/mymediaplayer/MainViewModel.kt
@@ -236,7 +236,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         }
 
         viewModelScope.launch(Dispatchers.IO) {
-            if (!forceRescan && !deepScan) {
+            if (!forceRescan) {
                 val persisted =
                     mediaCacheService.loadPersistedCache(getApplication(), treeUri, maxFiles)
                 if (persisted != null && persisted.files.isNotEmpty()) {
@@ -245,7 +245,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                         persisted.files,
                         persisted.playlists,
                         maxFiles,
-                        deepScan = false
+                        deepScan = deepScan
                     )
                     reimportPlaylistsFromSaveFolderIfNeeded()
                     metadataKey = null
@@ -290,9 +290,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             val files = mediaCacheService.cachedFiles
             val playlists = mediaCacheService.discoveredPlaylists
             scanCache[key] = files to playlists
-            if (!deepScan) {
-                mediaCacheService.persistCache(getApplication(), treeUri, maxFiles)
-            }
+            mediaCacheService.persistCache(getApplication(), treeUri, maxFiles)
             val message = formatDirectoryScanMessage(stats)
             _uiState.value = resetAfterScan(
                 files,


### PR DESCRIPTION
## Summary
- Fixes #326: deep scans previously bypassed both the persisted-cache read and write, so every app open with deep scan enabled triggered a full rescan and the deep-scan result was never cached.
- `onDirectorySelected` now loads from the persisted cache (if present) regardless of `deepScan`, and always persists the scan result afterward.
- The `deepScan` flag now only affects the probing behavior inside `scanDirectory` itself, as described in the issue.
- Kept the `scanCache`/`reimportPlaylistsFromSaveFolderIfNeeded` cache key consistent by passing the actual `deepScan` value into `resetAfterScan` on the persisted-cache-hit path.
- Updated the deep-scan checkbox label in `MainScreen.kt` to reflect the new caching behavior.

## Test plan
- [x] `./gradlew :mobile:compileDebugKotlin :mobile:testDebugUnitTest --tests "com.example.mymediaplayer.MainViewModel*"` — BUILD SUCCESSFUL
- [ ] Manual: enable deep scan, scan a folder, restart app, confirm cached results load instantly without a full rescan

🤖 Generated with [Claude Code](https://claude.com/claude-code)