### PR TITLE
Fix #345: Add Flagged smart playlist to phone app

### DIFF
--- a/mobile/src/main/java/com/example/mymediaplayer/MainScreen.kt
+++ b/mobile/src/main/java/com/example/mymediaplayer/MainScreen.kt
@@ -488,6 +488,7 @@ fun MainScreen(
                 LibraryTab.Playlists -> {
                     val smartPlaylists = remember(
                         uiState.favoriteUris,
+                        uiState.flaggedUris,
                         uiState.playCounts,
                         uiState.lastPlayedAt,
                         uiState.scan.scannedFiles
@@ -496,6 +497,10 @@ fun MainScreen(
                             PlaylistInfo(
                                 uriString = MainViewModel.SMART_FAVORITES,
                                 displayName = "Favorites.m3u"
+                            ),
+                            PlaylistInfo(
+                                uriString = MainViewModel.SMART_FLAGGED,
+                                displayName = "Flagged.m3u"
                             ),
                             PlaylistInfo(
                                 uriString = MainViewModel.SMART_RECENTLY_ADDED,

--- a/mobile/src/main/java/com/example/mymediaplayer/MainViewModel.kt
+++ b/mobile/src/main/java/com/example/mymediaplayer/MainViewModel.kt
@@ -130,6 +130,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         const val SMART_RECENTLY_ADDED = "${SMART_PREFIX}recently_added"
         const val SMART_MOST_PLAYED = "${SMART_PREFIX}most_played"
         const val SMART_NOT_HEARD_RECENTLY = "${SMART_PREFIX}not_heard_recently"
+        const val SMART_FLAGGED = "${SMART_PREFIX}flagged"
     }
 
     private val mediaCacheService = MediaCacheService()
@@ -1312,12 +1313,17 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             SMART_RECENTLY_ADDED -> getRecentlyAddedSongs(files)
             SMART_MOST_PLAYED -> getMostPlayedSongs(files, current.playCounts)
             SMART_NOT_HEARD_RECENTLY -> getNotHeardRecentlySongs(files, current.lastPlayedAt)
+            SMART_FLAGGED -> getFlaggedSongs(files, current.flaggedUris)
             else -> emptyList()
         }
     }
 
     private fun getFavoriteSongs(files: List<MediaFileInfo>, favoriteUris: Set<String>): List<MediaFileInfo> {
         return files.filter { it.uriString in favoriteUris }
+    }
+
+    private fun getFlaggedSongs(files: List<MediaFileInfo>, flaggedUris: Set<String>): List<MediaFileInfo> {
+        return files.filter { it.uriString in flaggedUris }
     }
 
     private fun getRecentlyAddedSongs(files: List<MediaFileInfo>): List<MediaFileInfo> {

--- a/mobile/src/test/java/com/example/mymediaplayer/MainViewModelTest.kt
+++ b/mobile/src/test/java/com/example/mymediaplayer/MainViewModelTest.kt
@@ -210,6 +210,43 @@ class MainViewModelTest {
         )
     }
 
+    @Test
+    fun selectPlaylist_flagged_returnsOnlyFlaggedFiles() {
+        val app = ApplicationProvider.getApplicationContext<Application>()
+        clearPrefs(app)
+        val viewModel = MainViewModel(app)
+        val files = listOf(
+            MediaFileInfo(
+                uriString = "content://test/songA",
+                displayName = "Song A",
+                sizeBytes = 1L,
+                title = "Song A"
+            ),
+            MediaFileInfo(
+                uriString = "content://test/songB",
+                displayName = "Song B",
+                sizeBytes = 1L,
+                title = "Song B"
+            )
+        )
+        val state = MainUiState(
+            scan = ScanState(scannedFiles = files, lastScanLimit = 10),
+            flaggedUris = setOf("content://test/songB"),
+            isPreferencesLoading = false
+        )
+        seedUiState(viewModel, state)
+
+        viewModel.selectPlaylist(
+            PlaylistInfo(
+                uriString = MainViewModel.SMART_FLAGGED,
+                displayName = "Flagged.m3u"
+            )
+        )
+        val resultUris = viewModel.uiState.value.playlist.playlistSongs.map { it.uriString }
+
+        assertEquals(listOf("content://test/songB"), resultUris)
+    }
+
     private fun seedScanState(
         viewModel: MainViewModel,
         files: List<MediaFileInfo>,


### PR DESCRIPTION
## Summary
- Fixes #345: the phone app's Flag/Unflag toggle (now-playing screen) persists `flaggedUris`, and `MyMusicService` (Android Auto/Automotive) already exposes a "Flagged" smart playlist from that data — but the phone UI had no way to browse it.
- Added `SMART_FLAGGED` constant and `getFlaggedSongs()` helper in `MainViewModel`, wired into `smartPlaylistSongs()`, mirroring the existing `SMART_FAVORITES`/`getFavoriteSongs()` implementation.
- Added a "Flagged.m3u" tile to the phone's playlist picker (`MainScreen.kt`), alongside Favorites/Recently Added/Most Played/Haven't Heard In A While.

## Test plan
- [x] `./gradlew :mobile:compileDebugKotlin :mobile:testDebugUnitTest --tests "com.example.mymediaplayer.MainViewModelTest"` — BUILD SUCCESSFUL (7/7 passing, including new `selectPlaylist_flagged_returnsOnlyFlaggedFiles`)
- [ ] Manual: flag a track from the now-playing screen, open Playlists tab, confirm "Flagged.m3u" appears and contains the flagged track

🤖 Generated with [Claude Code](https://claude.com/claude-code)