### PR TITLE
🧹 Remove unused coroutine imports in PlaylistService

### DIFF
--- a/shared/src/main/java/com/example/mymediaplayer/shared/PlaylistService.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/PlaylistService.kt
@@ -12,8 +12,6 @@ import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
 
 open class PlaylistService {
 


### PR DESCRIPTION
🎯 **What:** Removed unused imports `kotlinx.coroutines.async` and `kotlinx.coroutines.awaitAll` from `PlaylistService.kt`.
💡 **Why:** Reduces dead code, cleaning up the file, and improving readability and maintainability.
✅ **Verification:** Ran `./gradlew :shared:testDebugUnitTest` to confirm tests still pass and verified the diff using `git diff`.
✨ **Result:** A cleaner `PlaylistService.kt` file free of unused imports.

---
*PR created automatically by Jules for task [14503269451054752004](https://jules.google.com/task/14503269451054752004) started by @kimptoc*