### PR TITLE
🧪 [Testing Improvement] Add test for MediaCacheService clearCache

### DIFF
--- a/shared/src/test/java/com/example/mymediaplayer/shared/MediaCacheServiceTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/MediaCacheServiceTest.kt
@@ -242,4 +242,33 @@ class MediaCacheServiceTest {
         val songsUnknown = service.songsForDecade("1980s")
         assertTrue(songsUnknown.isEmpty())
     }
+
+    @Test
+    fun clearCache_emptiesFilesAndPlaylists() {
+        val service = MediaCacheService()
+
+        service.addFile(
+            MediaFileInfo(
+                uriString = "uri1",
+                displayName = "file1",
+                sizeBytes = 1000L,
+                album = "Album",
+                year = 1995
+            )
+        )
+        service.addPlaylist(PlaylistInfo("content://playlist1", "Playlist 1"))
+        service.buildAlbumArtistIndexesFromCache()
+
+        assertEquals(1, service.cachedFiles.size)
+        assertEquals(1, service.discoveredPlaylists.size)
+        assertTrue(service.hasAlbumArtistIndexes())
+        assertEquals(1, service.albums().size)
+
+        service.clearCache()
+
+        assertTrue(service.cachedFiles.isEmpty())
+        assertTrue(service.discoveredPlaylists.isEmpty())
+        assertFalse(service.hasAlbumArtistIndexes())
+        assertTrue(service.albums().isEmpty())
+    }
 }


### PR DESCRIPTION
🎯 **What:** Added missing test for the `MediaCacheService.clearCache` method.
📊 **Coverage:** Covered the scenario where files, playlists, and metadata indexes are populated and then `clearCache` is called, asserting that all caches and indices are emptied.
✨ **Result:** Improved test coverage for `MediaCacheService` by verifying cache invalidation behavior.

---
*PR created automatically by Jules for task [9190383477400701393](https://jules.google.com/task/9190383477400701393) started by @kimptoc*