### PR TITLE
🧪 Add basic test for MediaPlayerApplication

### DIFF
--- a/mobile/src/test/java/com/example/mymediaplayer/MediaPlayerApplicationTest.kt
+++ b/mobile/src/test/java/com/example/mymediaplayer/MediaPlayerApplicationTest.kt
@@ -5,7 +5,6 @@ import com.example.mymediaplayer.shared.BuildConfig
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
-import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -16,11 +15,6 @@ import timber.log.Timber
 @Config(application = MediaPlayerApplication::class)
 class MediaPlayerApplicationTest {
 
-    @Before
-    fun setUp() {
-        Timber.uprootAll()
-    }
-
     @After
     fun tearDown() {
         Timber.uprootAll()
@@ -28,10 +22,10 @@ class MediaPlayerApplicationTest {
 
     @Test
     fun `onCreate initializes Timber and does not crash`() {
+        // Robolectric instantiates the Application and calls onCreate() as part of
+        // ApplicationProvider.getApplicationContext(), so no manual onCreate() call here.
         val app = ApplicationProvider.getApplicationContext<MediaPlayerApplication>()
         assertNotNull(app)
-
-        app.onCreate()
 
         val expectedTreeCount = if (BuildConfig.DEBUG) 1 else 0
         assertEquals(expectedTreeCount, Timber.treeCount)

--- a/mobile/src/test/java/com/example/mymediaplayer/MediaPlayerApplicationTest.kt
+++ b/mobile/src/test/java/com/example/mymediaplayer/MediaPlayerApplicationTest.kt
@@ -1,0 +1,31 @@
+package com.example.mymediaplayer
+
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import timber.log.Timber
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = MediaPlayerApplication::class)
+class MediaPlayerApplicationTest {
+
+    @Before
+    fun setUp() {
+        Timber.uprootAll()
+    }
+
+    @Test
+    fun `onCreate initializes Timber and does not crash`() {
+        val app = ApplicationProvider.getApplicationContext<MediaPlayerApplication>()
+        assertNotNull(app)
+
+        app.onCreate()
+
+        assertTrue("Timber should have planted at least one tree", Timber.treeCount > 0)
+    }
+}

--- a/mobile/src/test/java/com/example/mymediaplayer/MediaPlayerApplicationTest.kt
+++ b/mobile/src/test/java/com/example/mymediaplayer/MediaPlayerApplicationTest.kt
@@ -1,8 +1,10 @@
 package com.example.mymediaplayer
 
 import androidx.test.core.app.ApplicationProvider
+import com.example.mymediaplayer.shared.BuildConfig
+import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -19,6 +21,11 @@ class MediaPlayerApplicationTest {
         Timber.uprootAll()
     }
 
+    @After
+    fun tearDown() {
+        Timber.uprootAll()
+    }
+
     @Test
     fun `onCreate initializes Timber and does not crash`() {
         val app = ApplicationProvider.getApplicationContext<MediaPlayerApplication>()
@@ -26,6 +33,7 @@ class MediaPlayerApplicationTest {
 
         app.onCreate()
 
-        assertTrue("Timber should have planted at least one tree", Timber.treeCount > 0)
+        val expectedTreeCount = if (BuildConfig.DEBUG) 1 else 0
+        assertEquals(expectedTreeCount, Timber.treeCount)
     }
 }


### PR DESCRIPTION
🎯 **What:** Added basic test for MediaPlayerApplication to verify it does not crash during `onCreate` and properly initializes Timber.
📊 **Coverage:** `MediaPlayerApplication.onCreate()`
✨ **Result:** Improved confidence that application initialization logic works correctly without regressions.

---
*PR created automatically by Jules for task [12976102545492371896](https://jules.google.com/task/12976102545492371896) started by @kimptoc*