### PR TITLE
🔒 [Security] Prevent DoS by limiting intent query strings before sanitization

### DIFF
--- a/shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
@@ -760,12 +760,12 @@ class MyMusicService : MediaBrowserServiceCompat() {
                 Log.w("MyMusicService", "Failed to read search query extra", e)
                 ""
             }
-            val sanitizedQuery = rawQuery.replace(SEARCH_INTENT_SANITIZE_REGEX, "")
-            val query = if (sanitizedQuery.length > 500) {
-                sanitizedQuery.substring(0, 500)
+            val truncatedQuery = if (rawQuery.length > 500) {
+                rawQuery.substring(0, 500)
             } else {
-                sanitizedQuery
+                rawQuery
             }
+            val query = truncatedQuery.replace(SEARCH_INTENT_SANITIZE_REGEX, "")
 
             val extras = Bundle().apply {
                 val allowedKeys = setOf(
@@ -780,8 +780,9 @@ class MyMusicService : MediaBrowserServiceCompat() {
                     try {
                         val value = intent.getStringExtra(key)
                         if (value != null) {
-                            val sanitizedValue = value.replace(SEARCH_INTENT_SANITIZE_REGEX, "")
-                            putString(key, if (sanitizedValue.length > 500) sanitizedValue.substring(0, 500) else sanitizedValue)
+                            val truncatedValue = if (value.length > 500) value.substring(0, 500) else value
+                            val sanitizedValue = truncatedValue.replace(SEARCH_INTENT_SANITIZE_REGEX, "")
+                            putString(key, sanitizedValue)
                         }
                     } catch (e: Exception) {
                         Log.w("MyMusicService", "Failed to read search intent extra '$key'", e)


### PR DESCRIPTION
🎯 **What:** Truncated the intent query strings and all associated intent string extras to 500 characters before running the sanitization regex replacement in `MyMusicService.kt`.

⚠️ **Risk:** An attacker could send a MediaBrowser intent containing extremely large strings, causing the service to consume excessive memory and CPU during the regular expression evaluation on potentially unbound inputs, resulting in a Denial of Service (DoS/ReDoS).

🛡️ **Solution:** By truncating the strings to a safe maximum length of 500 characters first, we guarantee that the regex engine strictly operates on bounded inputs of a known, small size, eliminating the DoS vector.

---
*PR created automatically by Jules for task [2287206647720099155](https://jules.google.com/task/2287206647720099155) started by @kimptoc*