### PR TITLE
🧪 [Testing] Add test for partial playlist reads on IOException

### DIFF
--- a/shared/src/test/java/com/example/mymediaplayer/shared/PlaylistServiceTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/PlaylistServiceTest.kt
@@ -97,6 +97,31 @@ class PlaylistServiceTest {
     }
 
     @Test
+    fun readPlaylist_returnsPartialResultsOnReadIOException() {
+        val baseContext = ApplicationProvider.getApplicationContext<Context>()
+        val uri = Uri.parse("content://test/playlist.m3u")
+        val shadowResolver = Shadows.shadowOf(baseContext.contentResolver)
+        shadowResolver.registerInputStreamSupplier(uri) {
+            val validData = "content://test/song1\n".toByteArray()
+            object : java.io.InputStream() {
+                var index = 0
+                override fun read(): Int {
+                    if (index < validData.size) {
+                        return validData[index++].toInt()
+                    }
+                    throw IOException("Mocked IO exception halfway")
+                }
+            }
+        }
+        val service = PlaylistService()
+
+        val results = service.readPlaylist(baseContext, uri)
+
+        assertTrue(results.size == 1)
+        assertTrue(results[0].uriString == "content://test/song1")
+    }
+
+    @Test
     fun appendToPlaylist_returnsFalseOnSecurityException() {
         val baseContext = ApplicationProvider.getApplicationContext<Context>()
         val uri = Uri.parse("content://test/playlist.m3u")


### PR DESCRIPTION
🎯 **What:** Added a test for `PlaylistService.readPlaylist` to verify that when an `IOException` occurs halfway through reading a playlist file, the method gracefully returns the partially parsed playlist items without crashing.
📊 **Coverage:** Covers the error handling block in `readPlaylist` when `reader.lineSequence().forEach` fails midway, specifically simulating the `BufferedReader` encountering a read failure after returning some lines.
✨ **Result:** Improved test reliability and coverage, ensuring that partial reads are correctly handled.

---
*PR created automatically by Jules for task [9324833467006185782](https://jules.google.com/task/9324833467006185782) started by @kimptoc*