### PR TITLE
🧪 [testing improvement] Add test for voice search query exception handling

### DIFF
--- a/mobile/src/test/java/com/example/mymediaplayer/MainActivityTest.kt
+++ b/mobile/src/test/java/com/example/mymediaplayer/MainActivityTest.kt
@@ -100,4 +100,25 @@ class MainActivityTest {
         assertEquals(500, genre?.length)
         assertEquals("a".repeat(500), genre)
     }
+
+    @Test
+    fun testVoiceSearchIntent_handlesExceptionWhenExtractingQuery() {
+        val intent = object : Intent("android.media.action.MEDIA_PLAY_FROM_SEARCH") {
+            override fun getStringExtra(name: String): String? {
+                if (name == SearchManager.QUERY) {
+                    throw RuntimeException("Simulated exception")
+                }
+                return super.getStringExtra(name)
+            }
+        }
+
+        val controller = Robolectric.buildActivity(MainActivity::class.java, intent)
+        val activity = controller.create().get()
+
+        val pendingVoiceSearchQueryField = MainActivity::class.java.getDeclaredField("pendingVoiceSearchQuery")
+        pendingVoiceSearchQueryField.isAccessible = true
+        val query = pendingVoiceSearchQueryField.get(activity) as? String
+
+        assertEquals("", query)
+    }
 }


### PR DESCRIPTION
🎯 **What:** Added a missing test case for `MainActivity.handleIncomingIntent` to ensure that exceptions thrown during `getStringExtra` for the voice search query are caught and default to an empty string.
📊 **Coverage:** The exception handling logic inside the try-catch block for reading `SearchManager.QUERY` from an intent is now covered.
✨ **Result:** Test coverage for voice search intent handling in `MainActivity` has increased, validating the exception fallback mechanism.

---
*PR created automatically by Jules for task [16414954827294441618](https://jules.google.com/task/16414954827294441618) started by @kimptoc*