### PR TITLE
🔒 Fix Path Traversal in PlaylistService

### DIFF
--- a/shared/src/main/java/com/example/mymediaplayer/shared/PlaylistService.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/PlaylistService.kt
@@ -58,12 +58,9 @@ open class PlaylistService {
         if (trimmed.isEmpty()) return null
 
         val root = DocumentFile.fromTreeUri(context, treeUri) ?: return null
-        val safeName = trimmed.replace("/", "_")
-        val fileName = if (safeName.endsWith(".m3u", ignoreCase = true)) {
-            safeName
-        } else {
-            "$safeName.m3u"
-        }
+        val rawBase = if (trimmed.endsWith(".m3u", ignoreCase = true)) trimmed.dropLast(4) else trimmed
+        val safeBase = rawBase.replace("/", "_").replace("\\", "_").replace(".", "_")
+        val fileName = "$safeBase.m3u"
         val target = root.createFile("audio/x-mpegurl", fileName) ?: run {
             Log.e(TAG, "Failed to create playlist file: $fileName")
             return null
@@ -189,12 +186,9 @@ open class PlaylistService {
     ): PlaylistInfo? {
         val trimmed = newName.trim()
         if (trimmed.isEmpty()) return null
-        val safeName = trimmed.replace("/", "_")
-        val finalName = if (safeName.endsWith(".m3u", ignoreCase = true)) {
-            safeName
-        } else {
-            "$safeName.m3u"
-        }
+        val rawBase = if (trimmed.endsWith(".m3u", ignoreCase = true)) trimmed.dropLast(4) else trimmed
+        val safeBase = rawBase.replace("/", "_").replace("\\", "_").replace(".", "_")
+        val finalName = "$safeBase.m3u"
 
         return try {
             val doc = DocumentFile.fromSingleUri(context, playlistUri)


### PR DESCRIPTION
🎯 **What:** Fixed a potential Path Traversal vulnerability in `PlaylistService`'s file creation and renaming logic by removing all backslashes and dots from user-supplied playlist names. Also removed an incompatible global `URLStreamHandlerFactory` from tests that was breaking Robolectric artifact fetching.

⚠️ **Risk:** An attacker could craft a malicious playlist name containing `..` or `\` to escape the intended Document Tree, potentially creating or overwriting arbitrary files on the filesystem outside of the app's scoped storage.

🛡️ **Solution:** Replaced all `/`, `\`, and `.` characters in the trimmed user-supplied name with underscores `_`. Correctly re-appended the `.m3u` extension if the original input explicitly intended it (using `dropLast()`), ensuring safety without breaking expected file extensions or playlist functionality. Fixed Robolectric `UnknownServiceException` test crashes by removing the faulty URL interceptor and restoring correct test behaviors.

---
*PR created automatically by Jules for task [16307226288427850582](https://jules.google.com/task/16307226288427850582) started by @kimptoc*