### PR TITLE
🧪 [testing improvement] Add test for MediaMetadataHelper handling IllegalStateException

### DIFF
--- a/shared/src/test/java/com/example/mymediaplayer/shared/MediaMetadataHelperTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/MediaMetadataHelperTest.kt
@@ -114,4 +114,18 @@ class MediaMetadataHelperTest {
         // The exception caught block should catch NPE and return null
         assertNull(result)
     }
+
+    @Test
+    fun extractMetadata_whenRetrieverThrowsIllegalStateException_returnsNull() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val uriString = "content://something/ise"
+        val uri = Uri.parse(uriString)
+
+        val dataSource = DataSource.toDataSource(context, uri)
+        ShadowMediaMetadataRetriever.addException(dataSource, IllegalStateException("Simulated state error"))
+
+        val result = MediaMetadataHelper.extractMetadata(context, uriString)
+
+        assertNull(result)
+    }
 }


### PR DESCRIPTION
🎯 **What:** The existing tests for `MediaMetadataHelper` verify that `IllegalArgumentException` and `NullPointerException` are handled properly, but lack verification for `IllegalStateException` which is a common exception for `MediaMetadataRetriever`.
📊 **Coverage:** A new test has been added to simulate `IllegalStateException` using `ShadowMediaMetadataRetriever`, verifying that `extractMetadata` properly catches it and returns null without crashing.
✨ **Result:** Increased test coverage for error conditions during metadata extraction, ensuring the fallback gracefully returns null on common state exceptions.

---
*PR created automatically by Jules for task [1240959092835643540](https://jules.google.com/task/1240959092835643540) started by @kimptoc*