### PR TITLE
🔒 Fix missing intent extra sanitization in BluetoothAutoPlayReceiver

### DIFF
--- a/mobile/src/main/java/com/example/mymediaplayer/BluetoothAutoPlayReceiver.kt
+++ b/mobile/src/main/java/com/example/mymediaplayer/BluetoothAutoPlayReceiver.kt
@@ -46,7 +46,7 @@ class BluetoothAutoPlayReceiver : BroadcastReceiver() {
                 intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE, BluetoothDevice::class.java)
             } else {
                 @Suppress("DEPRECATION")
-                intent.getParcelableExtra<android.os.Parcelable>(BluetoothDevice.EXTRA_DEVICE) as? BluetoothDevice
+                intent.getParcelableExtra<BluetoothDevice>(BluetoothDevice.EXTRA_DEVICE)
             }
         } catch (e: Exception) {
             null

--- a/mobile/src/main/java/com/example/mymediaplayer/BluetoothAutoPlayReceiver.kt
+++ b/mobile/src/main/java/com/example/mymediaplayer/BluetoothAutoPlayReceiver.kt
@@ -41,11 +41,15 @@ class BluetoothAutoPlayReceiver : BroadcastReceiver() {
             return
         }
 
-        val device = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE, BluetoothDevice::class.java)
-        } else {
-            @Suppress("DEPRECATION")
-            intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE)
+        val device = try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE, BluetoothDevice::class.java)
+            } else {
+                @Suppress("DEPRECATION")
+                intent.getParcelableExtra<android.os.Parcelable>(BluetoothDevice.EXTRA_DEVICE) as? BluetoothDevice
+            }
+        } catch (e: Exception) {
+            null
         } ?: run {
             record(prefs, "no_device")
             return

--- a/mobile/src/test/java/com/example/mymediaplayer/BluetoothAutoPlayReceiverSecurityTest.kt
+++ b/mobile/src/test/java/com/example/mymediaplayer/BluetoothAutoPlayReceiverSecurityTest.kt
@@ -1,0 +1,53 @@
+package com.example.mymediaplayer
+
+import android.content.Intent
+import android.graphics.Point
+import android.bluetooth.BluetoothDevice
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import android.os.Build
+import org.junit.Assert.*
+
+@RunWith(RobolectricTestRunner::class)
+class BluetoothAutoPlayReceiverSecurityTest {
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.S])
+    fun testInvalidExtraTypeBelowTiramisu() {
+        val receiver = BluetoothAutoPlayReceiver()
+        val context = ApplicationProvider.getApplicationContext<Context>()
+
+        // Put a String array instead of a BluetoothDevice
+        val intent = Intent(BluetoothDevice.ACTION_ACL_CONNECTED).apply {
+            putExtra(BluetoothDevice.EXTRA_DEVICE, arrayOf("Not a bluetooth device"))
+        }
+
+        try {
+            receiver.onReceive(context, intent)
+        } catch (e: Exception) {
+            fail("Should not crash on invalid extra type: ${e.message}")
+        }
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
+    fun testInvalidExtraTypeTiramisu() {
+        val receiver = BluetoothAutoPlayReceiver()
+        val context = ApplicationProvider.getApplicationContext<Context>()
+
+        // Put a String array instead of a BluetoothDevice
+        val intent = Intent(BluetoothDevice.ACTION_ACL_CONNECTED).apply {
+            putExtra(BluetoothDevice.EXTRA_DEVICE, arrayOf("Not a bluetooth device"))
+        }
+
+        try {
+            receiver.onReceive(context, intent)
+        } catch (e: Exception) {
+            fail("Should not crash on invalid extra type: ${e.message}")
+        }
+    }
+}

--- a/mobile/src/test/java/com/example/mymediaplayer/BluetoothAutoPlayReceiverSecurityTest.kt
+++ b/mobile/src/test/java/com/example/mymediaplayer/BluetoothAutoPlayReceiverSecurityTest.kt
@@ -1,7 +1,6 @@
 package com.example.mymediaplayer
 
 import android.content.Intent
-import android.graphics.Point
 import android.bluetooth.BluetoothDevice
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider


### PR DESCRIPTION
🎯 **What:** Added a try-catch block to safely extract the `BluetoothDevice` intent extra in `BluetoothAutoPlayReceiver`.
⚠️ **Risk:** Without sanitization, malicious applications could send invalid extras leading to a ClassCastException or BadParcelableException, resulting in a Denial of Service (app crash).
🛡️ **Solution:** Wrapped the extra extraction in a try-catch to catch potential parsing exceptions and fallback securely to a null device, returning early.

---
*PR created automatically by Jules for task [2187436558711493021](https://jules.google.com/task/2187436558711493021) started by @kimptoc*