### PR TITLE
🔒 [Security] Move Kilo API endpoint to BuildConfig

### DIFF
--- a/shared/src/main/java/com/example/mymediaplayer/shared/AnnouncementPreGenerator.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/AnnouncementPreGenerator.kt
@@ -41,7 +41,6 @@ internal class AnnouncementPreGenerator(
 ) {
     companion object {
         private const val TAG = "AnnouncementPreGen"
-        private const val KILO_ENDPOINT = "https://api.kilo.ai/api/gateway"
         private const val KILO_MODEL_ANON = "kilo/auto-free"
         private const val READY_TIMEOUT_MS = 5000L
 
@@ -246,7 +245,7 @@ internal class AnnouncementPreGenerator(
             val requestBody = bodyString.toRequestBody("application/json; charset=utf-8".toMediaType())
 
             val request = Request.Builder()
-                .url("$KILO_ENDPOINT/chat/completions")
+                .url("${BuildConfig.KILO_ENDPOINT}/chat/completions")
                 .header("Authorization", authHeader)
                 .post(requestBody)
                 .build()


### PR DESCRIPTION
🎯 **What:** Moved the hardcoded Kilo API endpoint from the source code (`AnnouncementPreGenerator.kt`) to `BuildConfig`.

⚠️ **Risk:** Hardcoding API endpoints directly in source files can expose internal or backend infrastructure details if the source code is leaked. More critically, it makes it impossible to change or rotate endpoints without releasing a full new application update. It also increases the risk of accidentally committing sensitive or internal endpoints to public version control.

🛡️ **Solution:** Modified `AnnouncementPreGenerator.kt` to reference `BuildConfig.KILO_ENDPOINT`. The value is now read dynamically during the build process from `local.properties` (with a secure default fallback) as configured in `shared/build.gradle`. This allows the endpoint to be configured safely per-environment without altering source code.

---
*PR created automatically by Jules for task [13160004220828477110](https://jules.google.com/task/13160004220828477110) started by @kimptoc*