### PR TITLE
fix(memory): avoid full cachedFiles copy on hot-path checks (#370)

### DIFF
--- a/shared/src/main/java/com/example/mymediaplayer/shared/MediaCacheService.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/MediaCacheService.kt
@@ -341,6 +341,12 @@ class MediaCacheService {
     private var _cachedMusicFiles: List<MediaFileInfo>? = null
     val cachedFiles: List<MediaFileInfo>
         get() = synchronized(cacheLock) { _cachedFiles.toList() }
+
+    val cachedFilesCount: Int
+        get() = synchronized(cacheLock) { _cachedFiles.size }
+
+    fun hasCachedFiles(): Boolean = synchronized(cacheLock) { _cachedFiles.isNotEmpty() }
+
     val cachedMusicFiles: List<MediaFileInfo>
         get() = synchronized(cacheLock) {
             var result = _cachedMusicFiles

--- a/shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
@@ -676,7 +676,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
         restorePlaybackSnapshot()
         mark("restorePlaybackSnapshot done")
         loadCachedTreeIfAvailable()
-        mark("loadCachedTreeIfAvailable returned (isScanning=$isScanning, cachedFiles=${mediaCacheService.cachedFiles.size})")
+        mark("loadCachedTreeIfAvailable returned (isScanning=$isScanning, cachedFiles=${mediaCacheService.cachedFilesCount})")
         mark("exit")
     }
 
@@ -837,7 +837,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
     }
 
     override fun onLoadChildren(parentId: String, result: Result<MutableList<MediaItem>>) {
-        Log.d("MyMusicService", "onLoadChildren($parentId) isScanning=$isScanning cachedFiles=${mediaCacheService.cachedFiles.size}")
+        Log.d("MyMusicService", "onLoadChildren($parentId) isScanning=$isScanning cachedFiles=${mediaCacheService.cachedFilesCount}")
         // No direct integration test for this gate: MediaBrowserServiceCompat.Result
         // has a package-private constructor and cannot be subclassed from our test
         // sources without a fake in androidx.media. The two operands are tested
@@ -1498,7 +1498,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
 
     private fun loadCachedTreeIfAvailable() {
         if (isScanning) return
-        if (mediaCacheService.cachedFiles.isNotEmpty()) return
+        if (mediaCacheService.hasCachedFiles()) return
         // Read scan settings from standard prefs — the activity always writes to standard prefs,
         // but getPrefs() may return encrypted prefs (which can be stale after settings changes).
         val standardPrefs = getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
@@ -2620,7 +2620,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
     }
 
     private suspend fun ensureCacheReadyForSearch() {
-        if (mediaCacheService.cachedFiles.isNotEmpty()) return
+        if (mediaCacheService.hasCachedFiles()) return
         val prefs = getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
         val uriString = prefs.getString(KEY_TREE_URI, null) ?: return
         val limit = prefs.getInt(KEY_SCAN_LIMIT, MediaCacheService.MAX_CACHE_SIZE)

--- a/shared/src/test/java/com/example/mymediaplayer/shared/MediaCacheServiceTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/MediaCacheServiceTest.kt
@@ -271,4 +271,28 @@ class MediaCacheServiceTest {
         assertFalse(service.hasAlbumArtistIndexes())
         assertTrue(service.albums().isEmpty())
     }
+
+    @Test
+    fun hasCachedFiles_reflectsCacheStateWithoutCopying() {
+        val service = MediaCacheService()
+        assertFalse(service.hasCachedFiles())
+
+        service.addFile(MediaFileInfo(uriString = "content://test/song1", displayName = "Song 1", sizeBytes = 100L, title = "Song 1"))
+        assertTrue(service.hasCachedFiles())
+
+        service.clearCache()
+        assertFalse(service.hasCachedFiles())
+    }
+
+    @Test
+    fun cachedFilesCount_matchesCachedFilesSize() {
+        val service = MediaCacheService()
+        assertEquals(0, service.cachedFilesCount)
+
+        service.addFile(MediaFileInfo(uriString = "content://test/song1", displayName = "Song 1", sizeBytes = 100L, title = "Song 1"))
+        service.addFile(MediaFileInfo(uriString = "content://test/song2", displayName = "Song 2", sizeBytes = 100L, title = "Song 2"))
+
+        assertEquals(2, service.cachedFilesCount)
+        assertEquals(service.cachedFiles.size, service.cachedFilesCount)
+    }
 }


### PR DESCRIPTION
## Summary
- Adds `MediaCacheService.hasCachedFiles()` and `cachedFilesCount` that read cache state without copying the 14k-item backing list.
- Updates `MyMusicService` startup/search/browse hot paths to use them instead of `cachedFiles.isNotEmpty()` / `cachedFiles.size`.

Part of the fix for #370 (OOM crash loop with a 14,209-file library). This is step 1 of 3 (Option B from the issue); Option A and Option C follow in separate PRs.

## Test plan
- [x] `./gradlew :shared:testDebugUnitTest` passes