### PR TITLE
fix(memory): stream persisted cache load from Room in pages (#370)

### DIFF
--- a/shared/src/main/java/com/example/mymediaplayer/shared/MediaCacheDatabase.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/MediaCacheDatabase.kt
@@ -50,7 +50,7 @@ interface MediaCacheDao {
     @Query("SELECT COUNT(*) FROM media_files")
     fun getFileCount(): Int
 
-    @Query("SELECT * FROM media_files LIMIT :limit OFFSET :offset")
+    @Query("SELECT * FROM media_files ORDER BY uriString LIMIT :limit OFFSET :offset")
     fun getFilesPage(limit: Int, offset: Int): List<MediaFileEntity>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)

--- a/shared/src/main/java/com/example/mymediaplayer/shared/MediaCacheDatabase.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/MediaCacheDatabase.kt
@@ -44,6 +44,8 @@ data class ScanStateEntity(
 
 @Dao
 interface MediaCacheDao {
+    /** Loads every row into memory at once — for production reads of a potentially large
+     * table, prefer [getFileCount] + [getFilesPage] to avoid materializing the full table. */
     @Query("SELECT * FROM media_files")
     fun getAllFiles(): List<MediaFileEntity>
 

--- a/shared/src/main/java/com/example/mymediaplayer/shared/MediaCacheDatabase.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/MediaCacheDatabase.kt
@@ -47,6 +47,12 @@ interface MediaCacheDao {
     @Query("SELECT * FROM media_files")
     fun getAllFiles(): List<MediaFileEntity>
 
+    @Query("SELECT COUNT(*) FROM media_files")
+    fun getFileCount(): Int
+
+    @Query("SELECT * FROM media_files LIMIT :limit OFFSET :offset")
+    fun getFilesPage(limit: Int, offset: Int): List<MediaFileEntity>
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun insertFiles(files: List<MediaFileEntity>)
 

--- a/shared/src/main/java/com/example/mymediaplayer/shared/MediaCacheService.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/MediaCacheService.kt
@@ -44,6 +44,10 @@ class MediaCacheService {
         // MediaMetadataRetriever.setDataSource can block indefinitely when MediaPlayer holds
         // the hardware codec. This timeout lets the batch continue with filename fallback.
         private const val METADATA_EXTRACT_TIMEOUT_MS = 2000L
+        // Keeps the Room entity page and the converted MediaFileInfo page small and
+        // short-lived, so the full raw entity list and the full converted list are
+        // never both resident in memory at once (see issue #370).
+        private const val PERSISTED_CACHE_PAGE_SIZE = 500
         private val SUPPORTED_AUDIO_EXTENSIONS = setOf(
             ".mp3", ".m4a", ".aac", ".flac", ".ogg", ".opus", ".wav", ".m4b",
             ".aiff", ".aif", ".wma", ".alac", ".ape", ".amr", ".awb",
@@ -524,12 +528,16 @@ class MediaCacheService {
         if (treeUri == MediaStore.Audio.Media.EXTERNAL_CONTENT_URI && isCacheStaleForWholeDevice(context, state.scannedAt)) {
             return null
         }
-        val files = dao.getAllFiles().let { fileEntities ->
-            val loadedFiles = ArrayList<MediaFileInfo>(fileEntities.size)
-            for (entity in fileEntities) {
-                loadedFiles.add(mediaFileFromEntity(entity))
+        val totalFiles = dao.getFileCount()
+        val files = ArrayList<MediaFileInfo>(totalFiles)
+        var offset = 0
+        while (offset < totalFiles) {
+            val page = dao.getFilesPage(limit = PERSISTED_CACHE_PAGE_SIZE, offset = offset)
+            if (page.isEmpty()) break
+            for (entity in page) {
+                files.add(mediaFileFromEntity(entity))
             }
-            loadedFiles
+            offset += page.size
         }
 
         val playlists = dao.getAllPlaylists().let { playlistEntities ->

--- a/shared/src/test/java/com/example/mymediaplayer/shared/MediaCacheServiceTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/MediaCacheServiceTest.kt
@@ -201,6 +201,53 @@ class MediaCacheServiceTest {
     }
 
     @Test
+    fun loadPersistedCache_loadsAllFilesAcrossMultiplePages() = runBlocking {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val db = MediaCacheDatabase.getInstance(context)
+        val dao = db.cacheDao()
+        val treeUri = Uri.parse("content://test/tree")
+
+        // More than one page at the production page size (500) to exercise paging.
+        val fileCount = 1200
+        withContext(Dispatchers.IO) {
+            dao.replaceCache(
+                files = (0 until fileCount).map { i ->
+                    MediaFileEntity(
+                        uriString = "content://test/song$i",
+                        displayName = "Song $i.mp3",
+                        sizeBytes = 100L,
+                        title = "Song $i",
+                        artist = "Artist",
+                        album = "Album",
+                        genre = "Rock",
+                        durationMs = 1000L,
+                        year = 2000,
+                        addedAtMs = 1L
+                    )
+                },
+                playlists = emptyList(),
+                state = ScanStateEntity(treeUri = treeUri.toString(), scanLimit = fileCount, scannedAt = 99L)
+            )
+        }
+
+        val service = MediaCacheService()
+        val persisted = withContext(Dispatchers.IO) {
+            service.loadPersistedCache(context, treeUri, maxFiles = fileCount)
+        }
+
+        assertNotNull(persisted)
+        assertEquals(fileCount, persisted!!.files.size)
+        assertEquals(fileCount, service.cachedFilesCount)
+        assertEquals(fileCount, persisted.files.map { it.uriString }.distinct().size)
+
+        withContext(Dispatchers.IO) {
+            dao.clearFiles()
+            dao.clearPlaylists()
+            dao.clearScanState()
+        }
+    }
+
+    @Test
     fun mediaCacheDao_getFilesPage_returnsRequestedSlice() = runBlocking {
         val context = ApplicationProvider.getApplicationContext<Context>()
         val db = MediaCacheDatabase.getInstance(context)

--- a/shared/src/test/java/com/example/mymediaplayer/shared/MediaCacheServiceTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/MediaCacheServiceTest.kt
@@ -201,6 +201,47 @@ class MediaCacheServiceTest {
     }
 
     @Test
+    fun mediaCacheDao_getFilesPage_returnsRequestedSlice() = runBlocking {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val db = MediaCacheDatabase.getInstance(context)
+        val dao = db.cacheDao()
+
+        withContext(Dispatchers.IO) {
+            dao.clearFiles()
+            val entities = (0 until 5).map { i ->
+                MediaFileEntity(
+                    uriString = "content://test/song$i",
+                    displayName = "Song $i",
+                    sizeBytes = 100L,
+                    title = "Song $i",
+                    artist = null,
+                    album = null,
+                    genre = null,
+                    durationMs = null,
+                    year = null,
+                    addedAtMs = null
+                )
+            }
+            dao.insertFiles(entities)
+        }
+
+        val count = withContext(Dispatchers.IO) { dao.getFileCount() }
+        assertEquals(5, count)
+
+        val firstPage = withContext(Dispatchers.IO) { dao.getFilesPage(limit = 2, offset = 0) }
+        val secondPage = withContext(Dispatchers.IO) { dao.getFilesPage(limit = 2, offset = 2) }
+        val thirdPage = withContext(Dispatchers.IO) { dao.getFilesPage(limit = 2, offset = 4) }
+
+        assertEquals(2, firstPage.size)
+        assertEquals(2, secondPage.size)
+        assertEquals(1, thirdPage.size)
+        val allUris = (firstPage + secondPage + thirdPage).map { it.uriString }.toSet()
+        assertEquals(5, allUris.size)
+
+        withContext(Dispatchers.IO) { dao.clearFiles() }
+    }
+
+    @Test
     fun songsForDecade_returnsCorrectSongs() {
         val service = MediaCacheService()
 


### PR DESCRIPTION
## Summary
- Adds `MediaCacheDao.getFileCount()` / `getFilesPage(limit, offset)` (with `ORDER BY uriString` for stable pagination).
- `MediaCacheService.loadPersistedCache` now loads and converts entities page-by-page (500 at a time) instead of materializing the full `List<MediaFileEntity>` and `List<MediaFileInfo>` simultaneously.

Part of the fix for #370 (OOM crash loop with a 14,209-file library). This is step 2 of 3 (Option A from the issue), built on top of the cachedFiles-copy fix in #371.

## Test plan
- [x] `./gradlew :shared:testDebugUnitTest` passes
- [x] New test `loadPersistedCache_loadsAllFilesAcrossMultiplePages` exercises >1 page (1200 files / 500-page-size)