### PR TITLE
fix(memory): build metadata indexes lazily instead of eagerly after scan (#370)

### DIFF
--- a/shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
@@ -1527,7 +1527,7 @@ class MyMusicService : MediaBrowserServiceCompat() {
             try {
                 val persisted = mediaCacheService.loadPersistedCache(this@MyMusicService, uri, limit)
                 if (persisted != null && persisted.files.isNotEmpty()) {
-                    mediaCacheService.buildAlbumArtistIndexesFromCache()
+                    // Index build is deferred until first browse (see ensureMetadataIndexes()).
                 } else {
                     var lastNotify = 0
                     val progress: (Int, Int) -> Unit = { songsFound, _ ->
@@ -1550,7 +1550,6 @@ class MyMusicService : MediaBrowserServiceCompat() {
                         )
                         mediaCacheService.enrichGenresFromMediaStore(this@MyMusicService)
                     }
-                    mediaCacheService.buildAlbumArtistIndexesFromCache()
                     mediaCacheService.persistCache(this@MyMusicService, uri, limit, scanStartedAt)
                 }
             } finally {

--- a/shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
@@ -1526,9 +1526,9 @@ class MyMusicService : MediaBrowserServiceCompat() {
         serviceScope.launch {
             try {
                 val persisted = mediaCacheService.loadPersistedCache(this@MyMusicService, uri, limit)
-                if (persisted != null && persisted.files.isNotEmpty()) {
-                    // Index build is deferred until first browse (see ensureMetadataIndexes()).
-                } else {
+                val cacheLoadedFromDisk = persisted != null && persisted.files.isNotEmpty()
+                // Index build is deferred until first browse (see ensureMetadataIndexes()).
+                if (!cacheLoadedFromDisk) {
                     var lastNotify = 0
                     val progress: (Int, Int) -> Unit = { songsFound, _ ->
                         if (songsFound - lastNotify >= 200) {

--- a/shared/src/test/java/com/example/mymediaplayer/shared/MyMusicServiceTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/MyMusicServiceTest.kt
@@ -438,6 +438,38 @@ class MyMusicServiceTest {
     }
 
     @Test
+    fun loadCachedTreeIfAvailable_indexesStayLazyUntilFirstBrowse() {
+        // Regression guard for issue #370. This test passes both before and after
+        // removing the eager buildAlbumArtistIndexesFromCache() calls in
+        // loadCachedTreeIfAvailable() — it is not a red/green TDD test, since that
+        // removal is non-behavioral (every read path already calls
+        // ensureMetadataIndexes() lazily, per benchmarkBuildHomeItemsWithUnindexedCache).
+        // Its job is to lock in the lazy-build contract this PR relies on.
+        val service = Robolectric.buildService(MyMusicService::class.java).get()
+        val cache = service.mediaCacheService
+
+        cache.addFile(
+            MediaFileInfo(
+                uriString = "content://test/song1",
+                displayName = "Song 1.mp3",
+                sizeBytes = 100L,
+                title = "Song 1",
+                artist = "Artist",
+                album = "Album",
+                genre = "Rock",
+                year = 1999
+            )
+        )
+
+        assertFalse(cache.hasAlbumArtistIndexes())
+
+        val items = service.buildHomeItems()
+
+        assertTrue(cache.hasAlbumArtistIndexes())
+        assertTrue(items.isNotEmpty())
+    }
+
+    @Test
     fun buildMediaItems_searchRootShowsPreviousSearches() {
         val service = Robolectric.buildService(MyMusicService::class.java).get()
         service.getSharedPreferences("mymediaplayer_prefs", android.content.Context.MODE_PRIVATE)


### PR DESCRIPTION
## Summary
- Removes the two unconditional `buildAlbumArtistIndexesFromCache()` calls in `MyMusicService.loadCachedTreeIfAvailable()`.
- Relies on the existing lazy-build path (`ensureMetadataIndexes()` / `hasAlbumArtistIndexes()`) already used by every album/genre/artist/decade browse handler and by the HOME_ID count tiles, so indexes are built on first real demand instead of immediately after every scan/cache-load.

Part of the fix for #370 (OOM crash loop with a 14,209-file library). This is step 3 of 3 (Option C from the issue), built on top of #371 and #372.

## Test plan
- [x] `./gradlew :shared:testDebugUnitTest :mobile:testDebugUnitTest` passes
- [x] New regression-guard test `loadCachedTreeIfAvailable_indexesStayLazyUntilFirstBrowse` locks in the lazy-build contract (indexes built on first `buildHomeItems()` call, not eagerly)