### PR TITLE
fix(memory): clear derived caches under critical memory pressure (#370)

### DIFF
--- a/mobile/src/main/java/com/example/mymediaplayer/MainActivity.kt
+++ b/mobile/src/main/java/com/example/mymediaplayer/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.example.mymediaplayer
 
 import android.annotation.SuppressLint
+import android.content.ComponentCallbacks2
 import android.content.ComponentName
 import android.content.Intent
 import android.media.AudioManager
@@ -551,6 +552,13 @@ class MainActivity : ComponentActivity() {
         mediaController?.unregisterCallback(controllerCallback)
         mediaBrowser?.disconnect()
         super.onDestroy()
+    }
+
+    override fun onTrimMemory(level: Int) {
+        super.onTrimMemory(level)
+        if (level >= ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL) {
+            viewModel.trimMemory()
+        }
     }
 
     override fun onNewIntent(intent: Intent) {

--- a/mobile/src/main/java/com/example/mymediaplayer/MainViewModel.kt
+++ b/mobile/src/main/java/com/example/mymediaplayer/MainViewModel.kt
@@ -190,6 +190,11 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         scanCache.clear()
     }
 
+    fun trimMemory() {
+        mediaCacheService.trimMemory()
+        scanCache.clear()
+    }
+
     internal fun resetAfterScan(
         files: List<MediaFileInfo>,
         playlists: List<PlaylistInfo>,

--- a/mobile/src/main/java/com/example/mymediaplayer/MainViewModel.kt
+++ b/mobile/src/main/java/com/example/mymediaplayer/MainViewModel.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.util.Locale
+import java.util.concurrent.ConcurrentHashMap
 
 data class ScanState(
     val isScanning: Boolean = false,
@@ -138,8 +139,10 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
 
     private val mediaCacheService = MediaCacheService()
     private val playlistService = PlaylistService()
+    // ConcurrentHashMap because trimMemory() can clear() from the main thread while
+    // scan coroutines on Dispatchers.IO are concurrently reading/writing the same map.
     private val scanCache =
-        mutableMapOf<String, Pair<List<MediaFileInfo>, List<PlaylistInfo>>>()
+        ConcurrentHashMap<String, Pair<List<MediaFileInfo>, List<PlaylistInfo>>>()
     private var treeUri: Uri? = null
     private var playlistTreeUri: Uri? = null
     private var metadataKey: String? = null

--- a/mobile/src/test/java/com/example/mymediaplayer/MainViewModelTrimMemoryTest.kt
+++ b/mobile/src/test/java/com/example/mymediaplayer/MainViewModelTrimMemoryTest.kt
@@ -1,0 +1,50 @@
+package com.example.mymediaplayer
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import com.example.mymediaplayer.shared.MediaCacheService
+import com.example.mymediaplayer.shared.MediaFileInfo
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class MainViewModelTrimMemoryTest {
+
+    @Test
+    fun trimMemory_clearsScanCacheAndIndexesButKeepsCachedFiles() {
+        val app = ApplicationProvider.getApplicationContext<Application>()
+        val viewModel = MainViewModel(app)
+
+        val mediaCacheField = viewModel.javaClass.getDeclaredField("mediaCacheService")
+        mediaCacheField.isAccessible = true
+        val mediaCache = mediaCacheField.get(viewModel) as MediaCacheService
+        mediaCache.addFile(
+            MediaFileInfo(
+                uriString = "content://test/song1",
+                displayName = "Song One",
+                sizeBytes = 1L,
+                title = "Song One",
+                album = "Album"
+            )
+        )
+        mediaCache.buildAlbumArtistIndexesFromCache()
+
+        val scanCacheField = viewModel.javaClass.getDeclaredField("scanCache")
+        scanCacheField.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        val scanCache = scanCacheField.get(viewModel) as MutableMap<String, String>
+        scanCache["key"] = "value"
+
+        assertTrue(mediaCache.hasAlbumArtistIndexes())
+
+        viewModel.trimMemory()
+
+        assertFalse(mediaCache.hasAlbumArtistIndexes())
+        assertTrue(scanCache.isEmpty())
+        assertEquals(1, mediaCache.cachedFiles.size)
+    }
+}

--- a/shared/src/main/java/com/example/mymediaplayer/shared/MediaCacheService.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/MediaCacheService.kt
@@ -851,6 +851,14 @@ class MediaCacheService {
         }
     }
 
+    // Drops rebuildable derived caches under memory pressure; _cachedFiles itself stays loaded.
+    fun trimMemory() {
+        synchronized(cacheLock) {
+            _cachedMusicFiles = null
+            clearMetadataIndexes()
+        }
+    }
+
     fun hasAlbumArtistIndexes(): Boolean = albumArtistIndexed
 
     fun buildAlbumArtistIndexesFromCache() {

--- a/shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
+++ b/shared/src/main/java/com/example/mymediaplayer/shared/MyMusicService.kt
@@ -1,5 +1,6 @@
 package com.example.mymediaplayer.shared
 
+import android.content.ComponentCallbacks2
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.Canvas
@@ -720,6 +721,13 @@ class MyMusicService : MediaBrowserServiceCompat() {
         currentPlaylistName = queueTitle
         updateSessionQueue()
         playTrack(playlistQueue[currentQueueIndex])
+    }
+
+    override fun onTrimMemory(level: Int) {
+        super.onTrimMemory(level)
+        if (level >= ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL) {
+            mediaCacheService.trimMemory()
+        }
     }
 
     override fun onDestroy() {

--- a/shared/src/test/java/com/example/mymediaplayer/shared/MediaCacheServiceTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/MediaCacheServiceTest.kt
@@ -361,6 +361,32 @@ class MediaCacheServiceTest {
     }
 
     @Test
+    fun trimMemory_clearsIndexesButKeepsCachedFiles() {
+        val service = MediaCacheService()
+
+        service.addFile(
+            MediaFileInfo(
+                uriString = "uri1",
+                displayName = "file1",
+                sizeBytes = 1000L,
+                album = "Album",
+                year = 1995
+            )
+        )
+        service.buildAlbumArtistIndexesFromCache()
+        service.cachedMusicFiles
+
+        assertTrue(service.hasAlbumArtistIndexes())
+        assertEquals(1, service.cachedFiles.size)
+
+        service.trimMemory()
+
+        assertFalse(service.hasAlbumArtistIndexes())
+        assertEquals(1, service.cachedFiles.size)
+        assertEquals(1, service.cachedMusicFiles.size)
+    }
+
+    @Test
     fun hasCachedFiles_reflectsCacheStateWithoutCopying() {
         val service = MediaCacheService()
         assertFalse(service.hasCachedFiles())

--- a/shared/src/test/java/com/example/mymediaplayer/shared/MyMusicServiceTest.kt
+++ b/shared/src/test/java/com/example/mymediaplayer/shared/MyMusicServiceTest.kt
@@ -470,6 +470,57 @@ class MyMusicServiceTest {
     }
 
     @Test
+    fun onTrimMemory_atRunningCriticalClearsIndexesButKeepsCachedFiles() {
+        val service = Robolectric.buildService(MyMusicService::class.java).get()
+        val cache = service.mediaCacheService
+
+        cache.addFile(
+            MediaFileInfo(
+                uriString = "content://test/song1",
+                displayName = "Song 1.mp3",
+                sizeBytes = 100L,
+                title = "Song 1",
+                artist = "Artist",
+                album = "Album",
+                genre = "Rock",
+                year = 1999
+            )
+        )
+        service.buildHomeItems()
+        assertTrue(cache.hasAlbumArtistIndexes())
+
+        service.onTrimMemory(android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL)
+
+        assertFalse(cache.hasAlbumArtistIndexes())
+        assertTrue(cache.hasCachedFiles())
+    }
+
+    @Test
+    fun onTrimMemory_belowRunningCriticalLeavesIndexesIntact() {
+        val service = Robolectric.buildService(MyMusicService::class.java).get()
+        val cache = service.mediaCacheService
+
+        cache.addFile(
+            MediaFileInfo(
+                uriString = "content://test/song1",
+                displayName = "Song 1.mp3",
+                sizeBytes = 100L,
+                title = "Song 1",
+                artist = "Artist",
+                album = "Album",
+                genre = "Rock",
+                year = 1999
+            )
+        )
+        service.buildHomeItems()
+        assertTrue(cache.hasAlbumArtistIndexes())
+
+        service.onTrimMemory(android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_MODERATE)
+
+        assertTrue(cache.hasAlbumArtistIndexes())
+    }
+
+    @Test
     fun buildMediaItems_searchRootShowsPreviousSearches() {
         val service = Robolectric.buildService(MyMusicService::class.java).get()
         service.getSharedPreferences("mymediaplayer_prefs", android.content.Context.MODE_PRIVATE)


### PR DESCRIPTION
## Summary
- Adds `MediaCacheService.trimMemory()`, which drops the rebuildable album/genre/artist/decade indexes and the `cachedMusicFiles` filter memo, while leaving the loaded file list (`cachedFiles`) intact.
- Wires it to `onTrimMemory()` in both `MyMusicService` and `MainActivity` (and clears the activity-side `scanCache` too), triggering at `TRIM_MEMORY_RUNNING_CRITICAL` or higher.
- Indexes rebuild lazily on next access via the existing `ensureMetadataIndexes()` path from #373 — no behavior change for normal use, just a defensive memory release under OS pressure.

This is **Option E** from #370, the last of the planned mitigations. B (#371), A (#372), and C (#373) are already merged and have eliminated the observed OOM crash loop in real-device testing (phone playback + head-unit emulator). This PR is a safety-net addition, not a fix for an active crash.

## Test plan
- [x] `./gradlew :shared:testDebugUnitTest :mobile:testDebugUnitTest` passes
- [x] New tests: `MediaCacheServiceTest.trimMemory_clearsIndexesButKeepsCachedFiles`, `MyMusicServiceTest.onTrimMemory_atRunningCriticalClearsIndexesButKeepsCachedFiles` / `onTrimMemory_belowRunningCriticalLeavesIndexesIntact`, `MainViewModelTrimMemoryTest.trimMemory_clearsScanCacheAndIndexesButKeepsCachedFiles`